### PR TITLE
Add: compare TargetPage and ResultPage logic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import styled, { ThemeProvider } from "styled-components";
 import theme from "./theme";
@@ -12,21 +12,38 @@ import TargetPage from "./components/TargetPage";
 import TagBlockContainer from "./components/TagBlockContainer";
 import HTMLViewer from "./components/HTMLViewer";
 
+import { compareChildTreeIds, compareChildTreeByBlockIds } from "./utils/selectData";
+import { MESSAGE } from "./constants";
+
 const AppWrapper = styled.div`
   display: grid;
   width: 100%;
   height: 100%;
   grid-template-rows: 2fr 1fr;
+`;
 
-  & > div {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
+const PageContainer = styled.div`
+  display: grid;
+  grid-template-columns: ${({ hasSingleChild }) => (hasSingleChild ? "1fr" : "1fr 1fr")};
+`;
+
+const DndInterface = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+`;
+
+const MessageContainer = styled.pre`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 function App() {
   const dispatch = useDispatch();
   const [hasError, setHasError] = useState(false);
+  const boilerplate = useSelector((state) => state.challenge.boilerplate, compareChildTreeIds);
+  const answer = useSelector((state) => state.challenge.answer, compareChildTreeIds);
+  const isCorrect = compareChildTreeByBlockIds(boilerplate, answer);
 
   useEffect(() => {
     async function fetchData() {
@@ -53,14 +70,18 @@ function App() {
           ? <div>현재 사이트 이용이 불가능합니다.</div>
           : (
             <>
-              <div>
+              <PageContainer hasSingleChild={isCorrect}>
                 <ResultPage />
-                <TargetPage />
-              </div>
-              <div>
-                <TagBlockContainer />
-                <HTMLViewer />
-              </div>
+                {!isCorrect && <TargetPage />}
+              </PageContainer>
+              {isCorrect
+                ? <MessageContainer>{MESSAGE.SUCCESS}</MessageContainer>
+                : (
+                  <DndInterface>
+                    <TagBlockContainer />
+                    <HTMLViewer />
+                  </DndInterface>
+                )}
             </>
           )}
       </AppWrapper>

--- a/src/components/DropContainer/index.jsx
+++ b/src/components/DropContainer/index.jsx
@@ -6,6 +6,12 @@ import Droppable from "../Droppable";
 import TagBlock from "../TagBlock";
 
 function DropContainer({ _id, tagName, childTrees }) {
+  function getValue(child) {
+    return child.isElementCluster
+      ? `<${child.block.tagName} />`
+      : `<${child.block.tagName}>${child.block.property.text}</${child.block.tagName}>`;
+  }
+
   return (
     <div>
       <span>{`<${tagName}>`}</span>
@@ -16,7 +22,7 @@ function DropContainer({ _id, tagName, childTrees }) {
         {childTrees.map((child, index) => (
           <Draggable key={child._id} _id={child._id} type={child.block.isContainer ? "container" : "tag"}>
             <>
-              {child.block.isContainer
+              {child.block.isContainer && !child.isElementCluster
                 ? (
                   <DropContainer
                     _id={child._id}
@@ -24,7 +30,7 @@ function DropContainer({ _id, tagName, childTrees }) {
                     tagName={child.block.tagName}
                   />
                 )
-                : <span>{`<${child.block.tagName}>${child.block.property.text}</${child.block.tagName}>`}</span>}
+                : <span>{getValue(child)}</span>}
               <Droppable _id={_id} index={index + 1}>
                 <div />
               </Droppable>

--- a/src/components/ElementBlock/index.jsx
+++ b/src/components/ElementBlock/index.jsx
@@ -2,20 +2,35 @@ import React, { createElement } from "react";
 import PropTypes from "prop-types";
 
 function ElementBlock({ _id, block, childTrees }) {
-  const { tagName, property } = block;
+  const { tagName, property, isContainer } = block;
+
+  if (isContainer) {
+    return createElement(
+      tagName,
+      { ...property, key: _id },
+      property.text,
+      childTrees.map((child) => (
+        <ElementBlock
+          key={child._id}
+          _id={child._id}
+          block={child.block}
+          childTrees={child.childTrees}
+        />
+      )),
+    );
+  }
+
+  if (property.text) {
+    return createElement(
+      tagName,
+      { ...property, key: _id },
+      property.text,
+    );
+  }
 
   return createElement(
     tagName,
     { ...property, key: _id },
-    property.text,
-    childTrees.map((child) => (
-      <ElementBlock
-        key={child._id}
-        _id={child._id}
-        block={child.block}
-        childTrees={child.childTrees}
-      />
-    )),
   );
 }
 
@@ -23,6 +38,7 @@ const blockTreeShape = {
   _id: PropTypes.string.isRequired,
   block: PropTypes.shape({
     tagName: PropTypes.string.isRequired,
+    isContainer: PropTypes.bool.isRequired,
     property: PropTypes.objectOf(
       PropTypes.oneOfType([
         PropTypes.string,

--- a/src/components/TagBlock/index.jsx
+++ b/src/components/TagBlock/index.jsx
@@ -2,14 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import Draggable from "../Draggable";
 
-function TagBlock({ _id, block }) {
+function TagBlock({ _id, isElementCluster, block }) {
   const { tagName, isContainer, property } = block;
-  const content = isContainer
+  const content = isContainer || isElementCluster
     ? `<${tagName} />`
     : `<${tagName}>${property.text}</${tagName}>`;
 
   return (
-    <Draggable _id={_id} type={isContainer ? "tag" : "container"}>
+    <Draggable _id={_id} type={isContainer ? "container" : "tag"}>
       <span>{content}</span>
     </Draggable>
   );
@@ -17,6 +17,7 @@ function TagBlock({ _id, block }) {
 
 TagBlock.propTypes = {
   _id: PropTypes.string.isRequired,
+  isElementCluster: PropTypes.bool.isRequired,
   block: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     tagName: PropTypes.string.isRequired,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+const MESSAGE = {
+  SUCCESS: "You did it!\nYou rock at MarkUp.",
+};
+
+export { MESSAGE };

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -15,9 +15,24 @@ export const challengeSlice = createSlice({
         title, tagBlocks, boilerplate, answer,
       } = payload;
 
+      const formattedTagBlocks = tagBlocks.map(
+        (child) => {
+          if (child.isElementCluster) {
+            return {
+              ...child,
+              childTrees: (findBlockTree(answer,
+                (block) => block.block._id === child.block._id)).childTrees,
+              hasUsed: false,
+            };
+          }
+
+          return { ...child, childTrees: [], hasUsed: false };
+        },
+      );
+
       return {
         title,
-        tagBlocks: tagBlocks.map((child) => ({ ...child, childTrees: [], hasUsed: false })),
+        tagBlocks: formattedTagBlocks,
         boilerplate,
         answer,
       };

--- a/src/utils/selectData.js
+++ b/src/utils/selectData.js
@@ -51,12 +51,42 @@ function compareChildTreeIds(left, right) {
     return false;
   }
 
-  if (left.childTrees.length === 0 && right.childTrees.length === 0) {
-    return true;
+  if (left.childTrees.length !== right.childTrees.length) {
+    return false;
   }
 
   return left.childTrees.every(
     (child, index) => compareChildTreeIds(child, right.childTrees[index]),
+  );
+}
+
+function compareChildTreeByBlockIds(left, right) {
+  if (left === null && right === null) {
+    return true;
+  }
+
+  if (left === null || right === null) {
+    return false;
+  }
+
+  if (!left?.block?._id || !right?.block?._id) {
+    return false;
+  }
+
+  if (left.block?._id !== right.block?._id) {
+    return false;
+  }
+
+  if (!left?.childTrees || !right?.childTrees) {
+    return false;
+  }
+
+  if (left.childTrees.length !== right.childTrees.length) {
+    return false;
+  }
+
+  return left.childTrees.every(
+    (child, index) => compareChildTreeByBlockIds(child, right.childTrees[index]),
   );
 }
 
@@ -65,4 +95,5 @@ export {
   findBlockTreeById,
   findTagBlockById,
   compareChildTreeIds,
+  compareChildTreeByBlockIds,
 };


### PR DESCRIPTION
closes #5 
![resultPage](https://user-images.githubusercontent.com/60309558/135978755-812be7ab-002e-44df-8849-bada5b15113b.gif)

- 완료 메시지를 constants에 추가하였습니다.
- childTrees의 blockId를 비교해 일치여부를 판별하는 함수 compareChildTreeByBlockIds를 util에 추가하였습니다.
- 위의 함수에서 true를 반환하면 완료 상태가 되고, DndInterface 대신 완료 메세지가 렌더링됩니다.
- 완료 상태가 되면 TargetPage 컴포넌트가 렌더링되지 않고, ResultPage만 렌더링됩니다.
- ElementBlock 컴포넌트의 경우, isContainer prop이 true일 경우에만 자식을 갖도록 수정하였습니다.
- 레이아웃 등의 스테이지에서, challenge state의 tagBlock이 childTrees를 갖고 있는 경우를 처리하기 위해 isElementCluster 속성을 추가하였습니다.
- related: https://github.com/mark-up-blocks/mark-up-blocks-server/pull/10
