### PR TITLE
Modify: element block

### DIFF
--- a/src/components/DropContainer/index.jsx
+++ b/src/components/DropContainer/index.jsx
@@ -6,7 +6,7 @@ import Droppable from "../Droppable";
 import TagBlock from "../TagBlock";
 
 function DropContainer({ _id, tagName, childTrees }) {
-  function getValue(child) {
+  function getTextValue(child) {
     return child.isElementCluster
       ? `<${child.block.tagName} />`
       : `<${child.block.tagName}>${child.block.property.text}</${child.block.tagName}>`;
@@ -30,7 +30,7 @@ function DropContainer({ _id, tagName, childTrees }) {
                     tagName={child.block.tagName}
                   />
                 )
-                : <span>{getValue(child)}</span>}
+                : <span>{getTextValue(child)}</span>}
               <Droppable _id={_id} index={index + 1}>
                 <div />
               </Droppable>

--- a/src/components/ElementBlock/index.jsx
+++ b/src/components/ElementBlock/index.jsx
@@ -2,13 +2,30 @@ import React, { createElement } from "react";
 import PropTypes from "prop-types";
 
 function ElementBlock({ _id, block, childTrees }) {
-  const { tagName, property, isContainer } = block;
+  const { tagName, isContainer } = block;
+
+  function preventDefault(event) {
+    event.preventDefault();
+  }
+
+  const eventHandlers = Object.keys(block.property).filter((attribute) => attribute.startsWith("on"));
+  const preventedHandlers = eventHandlers.reduce(
+    (accumulator, handler) => ({ ...accumulator, [handler]: preventDefault }),
+    {},
+  );
+
+  const property = {
+    ...block.property, key: _id, ...preventedHandlers, text: null,
+  };
+
+  if (tagName === "form") {
+    property.onSubmit = preventDefault;
+  }
 
   if (isContainer) {
     return createElement(
       tagName,
-      { ...property, key: _id },
-      property.text,
+      property,
       childTrees.map((child) => (
         <ElementBlock
           key={child._id}
@@ -20,17 +37,21 @@ function ElementBlock({ _id, block, childTrees }) {
     );
   }
 
-  if (property.text) {
+  if (["input", "textarea"].includes(tagName)) {
+    property.readOnly = true;
+  }
+
+  if (block.property.text) {
     return createElement(
       tagName,
-      { ...property, key: _id },
-      property.text,
+      property,
+      block.property.text,
     );
   }
 
   return createElement(
     tagName,
-    { ...property, key: _id },
+    { ...property, key: _id, ...preventedHandlers },
   );
 }
 

--- a/src/components/ElementBlock/index.jsx
+++ b/src/components/ElementBlock/index.jsx
@@ -51,7 +51,7 @@ function ElementBlock({ _id, block, childTrees }) {
 
   return createElement(
     tagName,
-    { ...property, key: _id, ...preventedHandlers },
+    property,
   );
 }
 

--- a/src/components/TagBlockContainer/index.jsx
+++ b/src/components/TagBlockContainer/index.jsx
@@ -18,8 +18,17 @@ function TagBlockContainer() {
 
   return (
     <ContainerWrapper>
-      {tagBlocks.map(({ _id, block, hasUsed }) => (
-        !hasUsed && <TagBlock key={_id} _id={_id} block={block} />
+      {tagBlocks.map(({
+        _id, block, hasUsed, isElementCluster,
+      }) => (
+        !hasUsed && (
+        <TagBlock
+          key={_id}
+          _id={_id}
+          block={block}
+          isElementCluster={isElementCluster}
+        />
+        )
       ))}
     </ContainerWrapper>
   );


### PR DESCRIPTION
closes #20 
- form 태그인 경우 submit 이벤트를 막아주었습니다.
- input, textarea인 경우 readOnly 속성을 추가해주었습니다.
- 텍스트노드를 위한 text 속성이 실제 태그에 전달되지 않도록 조치하였습니다.
- 직전 PR에서 누락되었던 TagBlock의 isElementCluster 프로퍼티를 추가해주었습니다.