### PR TITLE
Add: Stage menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,8 +5,9 @@ import styled, { ThemeProvider } from "styled-components";
 import theme from "./theme";
 import GlobalStyle from "./theme/global";
 
-import { setChallenge } from "./features/challenge";
-import { getChallenge } from "./api";
+import { setChallenge, setStageInfo, markStageCompleted } from "./features/challenge";
+import { getChallengeList, getChallenge } from "./api";
+import Header from "./components/Header";
 import ResultPage from "./components/ResultPage";
 import TargetPage from "./components/TargetPage";
 import TagBlockContainer from "./components/TagBlockContainer";
@@ -15,40 +16,38 @@ import HTMLViewer from "./components/HTMLViewer";
 import { compareChildTreeIds, compareChildTreeByBlockIds } from "./utils/selectData";
 import { MESSAGE } from "./constants";
 
-const AppWrapper = styled.div`
-  display: grid;
-  width: 100%;
-  height: 100%;
-  grid-template-rows: 2fr 1fr;
-`;
-
-const PageContainer = styled.div`
-  display: grid;
-  grid-template-columns: ${({ hasSingleChild }) => (hasSingleChild ? "1fr" : "1fr 1fr")};
-`;
-
-const DndInterface = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-`;
-
-const MessageContainer = styled.pre`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
 function App() {
   const dispatch = useDispatch();
   const [hasError, setHasError] = useState(false);
+  const { challengeId, isLoaded } = useSelector((state) => state.challenge);
   const boilerplate = useSelector((state) => state.challenge.boilerplate, compareChildTreeIds);
   const answer = useSelector((state) => state.challenge.answer, compareChildTreeIds);
   const isCorrect = compareChildTreeByBlockIds(boilerplate, answer);
+  const [selectedOption] = useState(0);
 
   useEffect(() => {
-    async function fetchData() {
+    async function fetchRootChallenge() {
       try {
-        const challenge = await getChallenge("id");
+        const { challenges } = await getChallengeList();
+        const rootChallenge = challenges[selectedOption];
+
+        dispatch(setStageInfo(rootChallenge));
+      } catch (err) {
+        if (process.env.NODE_ENV === "development") {
+          console.error(err);
+        }
+
+        setHasError(true);
+      }
+    }
+
+    fetchRootChallenge();
+  }, [dispatch, selectedOption]);
+
+  useEffect(() => {
+    async function fetchChallenge() {
+      try {
+        const challenge = await getChallenge(challengeId);
 
         dispatch(setChallenge(challenge));
       } catch (err) {
@@ -60,12 +59,25 @@ function App() {
       }
     }
 
-    fetchData();
-  }, [dispatch]);
+    if (!challengeId || isLoaded) {
+      return;
+    }
+
+    fetchChallenge();
+  }, [dispatch, isLoaded, challengeId]);
+
+  useEffect(() => {
+    if (!isCorrect) {
+      return;
+    }
+
+    dispatch(markStageCompleted());
+  }, [dispatch, isCorrect]);
 
   return (
     <ThemeProvider theme={theme}>
       <AppWrapper>
+        <Header />
         {hasError
           ? <div>현재 사이트 이용이 불가능합니다.</div>
           : (
@@ -91,3 +103,27 @@ function App() {
 }
 
 export default App;
+
+const AppWrapper = styled.div`
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-rows: 50px 4fr 3fr;
+`;
+
+const PageContainer = styled.div`
+  display: grid;
+  grid-template-columns: ${({ hasSingleChild }) => (hasSingleChild ? "1fr" : "1fr 1fr")};
+  margin: ${({ hasSingleChild }) => (hasSingleChild ? "0 auto" : "0")};
+`;
+
+const DndInterface = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+`;
+
+const MessageContainer = styled.pre`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -2,6 +2,20 @@ import axios from "axios";
 
 const baseURL = process.env.REACT_APP_API_SERVER_URI;
 
+async function getChallengeList() {
+  try {
+    const res = await axios.get(`${baseURL}/challenges`);
+
+    return res.data;
+  } catch (err) {
+    if (err.status === 500) {
+      throw new Error("internal server error");
+    }
+
+    throw err;
+  }
+}
+
 async function getChallenge(id) {
   try {
     const res = await axios.get(`${baseURL}/challenges/${id}`);
@@ -16,4 +30,4 @@ async function getChallenge(id) {
   }
 }
 
-export { getChallenge };
+export { getChallengeList, getChallenge };

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import styled from "styled-components";
+
+import StageMenu from "../StageMenu";
+
+function Header() {
+  const { title: stageTitle, stageInfo } = useSelector((state) => state.challenge);
+  const [isStageMenuOpen, setIsStageMenuOpen] = useState(false);
+  const stageData = useSelector((state) => state.challenge.stageInfo.rootChallenge.data);
+
+  return (
+    <HeaderWrapper>
+      <Title>Mark Up Blocks</Title>
+      <Nav>
+        {isStageMenuOpen && (
+        <MenuWrapper>
+          <StageMenu
+            _id={stageData._id}
+            title={stageData.title}
+            childChallenges={stageData.childChallenges}
+          />
+        </MenuWrapper>
+        )}
+        <ChallengeName>{stageInfo.rootChallenge.name}</ChallengeName>
+        <Stage onClick={() => setIsStageMenuOpen((prev) => !prev)}>{stageTitle || "Stage"}</Stage>
+      </Nav>
+    </HeaderWrapper>
+  );
+}
+
+export default Header;
+
+const HeaderWrapper = styled.header`
+  display: flex;
+  position: relative;
+  color: ${({ theme }) => theme.color.inner};
+  background-color: ${({ theme }) => theme.color.main};
+  justify-content: space-between;
+  align-items: center;
+  font-family: "Noto Sans Display", sans-serif;
+`;
+
+const Title = styled.h2`
+  margin: 10px;
+  font-size: 1.8rem;
+`;
+
+const Nav = styled.nav`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const ChallengeName = styled.h3`
+  margin: 10px;
+  font-size: 1.3rem;
+`;
+
+const Stage = styled.button`
+  width: 100px;
+  margin: 10px;
+  padding: 5px 10px;
+  font-size: 1.15em;
+  color: ${({ theme }) => theme.color.main};
+  background-color: ${({ theme }) => theme.color.inner};
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.color.focus};
+  }
+`;
+
+const MenuWrapper = styled.ol`
+  position: absolute;
+  top: 48px;
+  right: 10px;
+  min-width: 100px;
+  padding: 5px;
+  background-color: ${({ theme }) => theme.color.inner};
+  border: 2px solid ${({ theme }) => theme.color.main};
+  border-radius: 4px;
+  box-shadow: 2px 2px 3px gray;
+`;

--- a/src/components/StageMenu/index.jsx
+++ b/src/components/StageMenu/index.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useDispatch } from "react-redux";
+import styled from "styled-components";
+
+import { changeStage } from "../../features/challenge";
+
+function StageMenu({ _id, title, childChallenges }) {
+  const dispatch = useDispatch();
+  const handleClick = () => dispatch(changeStage(_id));
+
+  return (
+    <Li>
+      <StageButton type="button" onClick={handleClick}>
+        {title}
+      </StageButton>
+      {childChallenges.length ? (
+        <ol>
+          {childChallenges.map((child) => (
+            <StageMenu
+              key={child._id}
+              _id={child._id}
+              title={child.title}
+              childChallenges={child.childChallenges}
+            />
+          ))}
+        </ol>
+      ) : <></>}
+    </Li>
+  );
+}
+
+const menuSchema = {
+  _id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+StageMenu.propTypes = {
+  ...menuSchema,
+  childChallenges: PropTypes.arrayOf(
+    PropTypes.shape(menuSchema),
+  ).isRequired,
+};
+
+export default StageMenu;
+
+const Li = styled.li`
+  margin: 5px 0px 5px 15px;
+`;
+
+const StageButton = styled.button`
+  width: 100%;
+  padding: 5px;
+  color: ${({ theme }) => theme.color.text};
+  text-align: left;
+
+  :hover {
+    background-color: ${({ theme }) => theme.color.main};
+  }
+`;

--- a/src/theme/global.js
+++ b/src/theme/global.js
@@ -12,6 +12,17 @@ const GlobalStyle = createGlobalStyle`
   a {
     text-decoration: none;
   }
+
+  button {
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+  }
+
+  @font-face {
+    font-family: "Noto Sans Display";
+    src: url("https://fonts.googleapis.com/css2?family=Noto+Sans+Display:wght@100&display=swap");
+  }
 `;
 
 export default GlobalStyle;

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,8 +1,16 @@
+const color = {
+  main: "#FBC00E",
+  inner: "#fff",
+  focus: "#fff7de",
+  text: "#000",
+};
+
 const border = {
   page: "2px solid #FBC00E",
 };
 
 const theme = {
+  color,
   border,
 };
 

--- a/src/utils/selectData.js
+++ b/src/utils/selectData.js
@@ -90,10 +90,31 @@ function compareChildTreeByBlockIds(left, right) {
   );
 }
 
+function findChallengeById(root, challengeId) {
+  const queue = [root];
+
+  while (queue.length) {
+    const currentNode = queue.shift();
+
+    if (currentNode) {
+      if (currentNode._id === challengeId) {
+        return currentNode;
+      }
+
+      if (currentNode.childChallenges) {
+        queue.push(...currentNode.childChallenges);
+      }
+    }
+  }
+
+  return null;
+}
+
 export {
   findBlockTree,
   findBlockTreeById,
   findTagBlockById,
   compareChildTreeIds,
   compareChildTreeByBlockIds,
+  findChallengeById,
 };


### PR DESCRIPTION
closes #6 
![stageMenu](https://user-images.githubusercontent.com/60309558/136168485-5404c41f-43eb-4b21-9b60-2a4746373f65.gif)

- 스테이지 메뉴바와 이동 관련 로직입니다.
- 오른쪽 상단에 현재 플레이중인 rootChallenge(텍스트), challenge(버튼) 정보가 표시됩니다.
- 스테이지 버튼을 클릭하면 스테이지 목록이 메뉴 형태로 출력됩니다.
- 목록을 클릭해 다른 스테이지로 이동할 수 있습니다. 이동시 플레이 중이었던 스테이지 정보는 redux store의 challenge.stageInfo에 보관됩니다.