### PR TITLE
Add: Preview, Tutorial component

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.21.4",
+    "lodash.debounce": "^4.0.8",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dnd": "^14.0.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,8 +10,8 @@ import { setStageInfo } from "./features/challenge";
 import { getChallengeList } from "./api";
 import Header from "./components/Header";
 import Puzzle from "./components/Puzzle";
-import { findNextUncompletedChallenge } from "./utils/selectData";
 import Tutorial from "./components/Tutorial";
+import { findNextUncompletedChallenge } from "./utils/selectData";
 
 function App() {
   const dispatch = useDispatch();

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { getChallengeList } from "./api";
 import Header from "./components/Header";
 import Puzzle from "./components/Puzzle";
 import { findNextUncompletedChallenge } from "./utils/selectData";
+import Tutorial from "./components/Tutorial";
 
 function App() {
   const dispatch = useDispatch();
@@ -39,6 +40,10 @@ function App() {
       setIsDone(true);
     }
   };
+  const handleTitleClick = () => {
+    history.push("/");
+    setHasError(false);
+  };
 
   useEffect(() => {
     async function fetchRootChallenge() {
@@ -58,11 +63,14 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <AppWrapper>
-        <Header onMenuClick={handleMenuClick} />
+        <Header onMenuClick={handleMenuClick} onTitleClick={handleTitleClick} />
         {hasError
           ? <div>현재 사이트 이용이 불가능합니다.</div>
           : (
             <Switch>
+              <Route exact path="/">
+                <Tutorial onFinish={handleFinishQuiz} />
+              </Route>
               <Route path="/:id">
                 <Puzzle
                   notifyError={notifyError}

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -5,14 +5,14 @@ import styled from "styled-components";
 
 import StageMenu from "./StageMenu";
 
-function Header({ onMenuClick }) {
+function Header({ onTitleClick, onMenuClick }) {
   const { title: stageTitle, stageInfo } = useSelector((state) => state.challenge);
   const [isStageMenuOpen, setIsStageMenuOpen] = useState(false);
   const stageData = useSelector((state) => state.challenge.stageInfo.rootChallenge.data);
 
   return (
     <HeaderWrapper>
-      <Title>Mark Up Blocks</Title>
+      <Title onClick={onTitleClick}>Mark Up Blocks</Title>
       <Nav>
         {isStageMenuOpen && (
         <MenuWrapper>
@@ -32,6 +32,7 @@ function Header({ onMenuClick }) {
 }
 
 Header.propTypes = {
+  onTitleClick: PropTypes.func.isRequired,
   onMenuClick: PropTypes.func.isRequired,
 };
 
@@ -50,6 +51,7 @@ const HeaderWrapper = styled.header`
 const Title = styled.h2`
   margin: 10px;
   font-size: 1.8rem;
+  cursor: pointer;
 `;
 
 const Nav = styled.nav`

--- a/src/components/Puzzle/TagBlock/index.jsx
+++ b/src/components/Puzzle/TagBlock/index.jsx
@@ -1,17 +1,54 @@
-import React from "react";
+import React, { useRef, useState, useEffect } from "react";
 import PropTypes from "prop-types";
+import debounce from "lodash.debounce";
+import styled from "styled-components";
 import Draggable from "../Draggable";
+import ElementBlock from "../ElementBlock";
+import { convertCamelToKebab, calcPosition } from "../../../utils/formatData";
 
 function TagBlock({ _id, isChallenge, block }) {
+  const ref = useRef(null);
   const { tagName, isContainer, property } = block;
   const content = isContainer || isChallenge
     ? `<${tagName} />`
     : `<${tagName}>${property.text}</${tagName}>`;
+  const [{ top, left }, setPosition] = useState({ top: 0, left: 0 });
+  const styles = Object.entries(block?.property?.style || {})
+    .map(([key, value]) => [convertCamelToKebab(key), value])
+    .sort((a, b) => b[0] > a[0]);
+
+  useEffect(() => {
+    const handleGetPosition = debounce(() => setPosition(calcPosition(ref?.current)), 300);
+
+    window.addEventListener("resize", handleGetPosition);
+
+    if (ref?.current) {
+      handleGetPosition();
+    }
+
+    return () => window.removeEventListener("resize", handleGetPosition);
+  }, []);
 
   return (
-    <Draggable _id={_id} type={isContainer ? "container" : "tag"}>
-      <span>{content}</span>
-    </Draggable>
+    <TagBlockWrapper top={top} left={left}>
+      <Draggable _id={_id} type={isContainer ? "container" : "tag"}>
+        <span>{content}</span>
+      </Draggable>
+      <Preview ref={ref} className="preview">
+        <div className="preview-element">
+          <ElementBlock
+            _id="preview"
+            block={block}
+            childTrees={[]}
+          />
+        </div>
+        <div className="preview-style">
+          {styles.map(([key, value]) => (
+            <p key={key}>{`${key}: ${value};`}</p>
+          ))}
+        </div>
+      </Preview>
+    </TagBlockWrapper>
   );
 }
 
@@ -32,3 +69,63 @@ TagBlock.propTypes = {
 };
 
 export default TagBlock;
+
+const TagBlockWrapper = styled.div`
+  position: relative;
+  border-radius: 10px;
+  border: 1px solid gray;
+  margin: 10px;
+
+  .preview {
+    position: absolute;
+    opacity: 0;
+    visibility: hidden;
+    top: ${({ top }) => (top ? `${top - 5}px` : "30px")};
+    left: ${({ left }) => (left ? `${left}px` : "auto")};
+    transition: all 0.25s;
+  }
+
+  :hover {
+    .preview {
+      opacity: 1;
+      z-index: 1;
+      visibility: visible;
+      top: ${({ top }) => (top ? `${top - 5}px` : "30px")};
+      left: ${({ left }) => (left ? `${left}px` : "auto")};
+    }
+  }
+`;
+
+const Preview = styled.div`
+  display: grid;
+  width: 250px;
+  max-height: 200px;
+  overflow: auto;
+  padding: 10px;
+  color: white;
+  background-color: darkgray;
+  border: 1px solid ${({ theme }) => theme.color.main};
+  border-radius: 4px;
+  justify-content: start;
+
+  .preview-element {
+    display: flex;
+    margin: auto;
+    padding: 10px;
+    background-color: white;
+    border-radius: 4px;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .preview-style {
+    width: 100%;
+    max-height: 30px;
+    margin: 5px;
+    padding: 5px;
+
+    p {
+      padding: 2px;
+    }
+  }
+`;

--- a/src/components/Tutorial/index.jsx
+++ b/src/components/Tutorial/index.jsx
@@ -44,7 +44,7 @@ function Tutorial({ onFinish }) {
   };
 
   return (
-    <Grid>
+    <div>
       {isDone
         ? (
           <div>
@@ -59,7 +59,7 @@ function Tutorial({ onFinish }) {
         : (
           <>
             <div>Mark Up Blocks에 오신 것을 환영합니다! 아래 태그 블록을 div 안으로 옮겨볼까요?</div>
-            <div className="grid">
+            <DnDInterface>
               <TagBlockContainer>
                 {tutorialBlocks.map(({
                   _id, block, hasUsed, isChallenge,
@@ -82,10 +82,10 @@ function Tutorial({ onFinish }) {
                   onDrop={handleDrop}
                 />
               </HTMLViewer>
-            </div>
+            </DnDInterface>
           </>
         )}
-    </Grid>
+    </div>
   );
 }
 
@@ -95,23 +95,12 @@ Tutorial.propTypes = {
 
 export default Tutorial;
 
-const Grid = styled.div`
+const DnDInterface = styled.div`
   display: grid;
-  width: 80%;
-  height: 80%;
-
-  .grid {
-    display: grid;
-    width: 100%;
-    height: 100%;
-    margin: auto;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .preview-container {
-    width: 200px;
-    height: 100px;
-  }
+  width: 100%;
+  height: 100%;
+  margin: auto;
+  grid-template-columns: 1fr 1fr;
 `;
 
 const TagBlockContainer = styled.div`

--- a/src/components/Tutorial/index.jsx
+++ b/src/components/Tutorial/index.jsx
@@ -1,0 +1,131 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import DropContainer from "../Puzzle/DropContainer";
+import TagBlock from "../Puzzle/TagBlock";
+import ArrowButton from "../Button/Arrow";
+
+const sampleBlock = {
+  _id: "tutorial1",
+  block: {
+    _id: "tutorial1",
+    tagName: "p",
+    isContainer: false,
+    property: {
+      text: "Move me",
+      style: {
+        width: "100px",
+        height: "30px",
+        backgroundColor: "gold",
+      },
+    },
+  },
+  hasUsed: false,
+  isChallenge: false,
+};
+
+function Tutorial({ onFinish }) {
+  const [isDone, setIsDone] = useState(false);
+  const [tutorialBlocks, setTutorialBlocks] = useState([sampleBlock]);
+  const [childTrees, setChildTrees] = useState([]);
+  const handleDrop = () => {
+    setTutorialBlocks(() => [{
+      ...sampleBlock,
+      hasUsed: true,
+    }]);
+    setChildTrees([sampleBlock]);
+    setIsDone(true);
+  };
+  const handleReset = () => {
+    setIsDone(false);
+    setTutorialBlocks([sampleBlock]);
+    setChildTrees([]);
+  };
+
+  return (
+    <Grid>
+      {isDone
+        ? (
+          <div>
+            <p>좋아요 !</p>
+            <button type="button" onClick={handleReset}>한번 더?</button>
+            <div className="grid">
+              <span>다음 스테이지</span>
+              <ArrowButton onClick={onFinish} />
+            </div>
+          </div>
+        )
+        : (
+          <>
+            <div>Mark Up Blocks에 오신 것을 환영합니다! 아래 태그 블록을 div 안으로 옮겨볼까요?</div>
+            <div className="grid">
+              <TagBlockContainer>
+                {tutorialBlocks.map(({
+                  _id, block, hasUsed, isChallenge,
+                }) => (
+                  !hasUsed && (
+                  <TagBlock
+                    key={_id}
+                    _id={_id}
+                    block={block}
+                    isChallenge={isChallenge}
+                  />
+                  )
+                ))}
+              </TagBlockContainer>
+              <HTMLViewer>
+                <DropContainer
+                  _id="tutorialBox"
+                  tagName="div"
+                  childTrees={childTrees}
+                  onDrop={handleDrop}
+                />
+              </HTMLViewer>
+            </div>
+          </>
+        )}
+    </Grid>
+  );
+}
+
+Tutorial.propTypes = {
+  onFinish: PropTypes.func.isRequired,
+};
+
+export default Tutorial;
+
+const Grid = styled.div`
+  display: grid;
+  width: 80%;
+  height: 80%;
+
+  .grid {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    margin: auto;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .preview-container {
+    width: 200px;
+    height: 100px;
+  }
+`;
+
+const TagBlockContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  margin: 10px;
+  justify-content: center;
+  align-items: center;
+  border: ${({ theme }) => theme.border.page};
+`;
+
+const HTMLViewer = styled.div`
+  display: grid;
+  align-items: center;
+  margin: 10px;
+  border: ${({ theme }) => theme.border.page};
+`;

--- a/src/utils/formatData.js
+++ b/src/utils/formatData.js
@@ -1,0 +1,38 @@
+function convertCamelToKebab(string) {
+  return [...string]
+    .map((char, index) => (
+      char === char.toUpperCase() && char.toLowerCase() !== char.toUpperCase() && index !== 0
+        ? `-${char.toLowerCase()}`
+        : char))
+    .join("");
+}
+
+function calcPosition(ref) {
+  const result = {
+    top: 0,
+    left: 0,
+  };
+
+  if (!ref) {
+    return result;
+  }
+
+  const {
+    top, left, width, height,
+  } = ref.getBoundingClientRect();
+
+  if (left + width > (window.innerWidth / 2)) {
+    result.left -= (left + width - (window.innerWidth / 2));
+  }
+
+  if (top + height > window.innerHeight) {
+    result.top -= height;
+  }
+
+  return result;
+}
+
+export {
+  convertCamelToKebab,
+  calcPosition,
+};


### PR DESCRIPTION
closes #18 
closes #10 
![preview](https://user-images.githubusercontent.com/60309558/136586425-b8b1cedb-217e-43b6-a131-0f92c2406cff.gif)

- 기존 설명 말풍선으로 구상했던 튜토리얼을 튜토리얼 컨텐츠와 말풍선 preview로 분리하였습니다.
- TagBlock 컴포넌트에 preview를 추가하였습니다.
  - hover시 해당 태그에 해당하는 element 예시와 style이 노출됩니다.
  - preview가 오른쪽 하단의 HTMLViewer를 가리지 않고, 화면 아래로 가지 않도록 하는 위치 조절 로직이 포함되어 있습니다.
- 튜토리얼 페이지를 추가하였습니다
  - 왼쪽 상단의 타이틀 Mark Up Blocks를 클릭하면 튜토리얼 페이지로 이동합니다.
- styled 컴포넌트를 별도로 분리하여 중복 제거와 관심사 분리하는 작업이 필요할 것 같습니다. -> 이슈 오픈하였습니다 #27 