### PR TITLE
Refactor: replace tagBlock's hasUsed prop as default container

### DIFF
--- a/src/components/Puzzle/DndInterface/Droppable/index.jsx
+++ b/src/components/Puzzle/DndInterface/Droppable/index.jsx
@@ -4,7 +4,7 @@ import { useDrop } from "react-dnd";
 import styled from "styled-components";
 
 function Droppable({
-  children, _id, index, onDrop,
+  children, _id, index, onDrop, className,
 }) {
   const [{ hovered }, dropRef] = useDrop(() => ({
     accept: ["tag", "container"],
@@ -25,13 +25,14 @@ function Droppable({
   }), [_id, index]);
 
   return (
-    <DroppableWrapper ref={dropRef} hovered={hovered}>
+    <DroppableWrapper className={className} ref={dropRef} hovered={hovered}>
       {children}
     </DroppableWrapper>
   );
 }
 
 Droppable.propTypes = {
+  className: PropTypes.string,
   _id: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.element,
@@ -42,6 +43,7 @@ Droppable.propTypes = {
 };
 
 Droppable.defaultProps = {
+  className: "",
   index: -1,
 };
 

--- a/src/components/Puzzle/DndInterface/index.jsx
+++ b/src/components/Puzzle/DndInterface/index.jsx
@@ -3,10 +3,11 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import TagBlock from "./TagBlock";
+import Droppable from "./Droppable";
 import DropContainer from "./DropContainer";
 
 function DndInterface({
-  tagBlocks, boilerplate, onDrop, className,
+  tagBlockContainer, boilerplate, onDrop, className,
 }) {
   const handleDrop = ({ itemId, containerId, index }) => {
     onDrop({ itemId, containerId, index });
@@ -14,18 +15,14 @@ function DndInterface({
 
   return (
     <DndInterfaceWrapper className={className}>
-      <TagBlockContainer>
-        {tagBlocks.map(({
-          _id, block, hasUsed, isChallenge,
-        }) => (
-          !hasUsed && (
+      <TagBlockContainer _id="tagBlockContainer" onDrop={onDrop}>
+        {tagBlockContainer.childTrees.map(({ _id, isChallenge, block }) => (
           <TagBlock
             key={_id}
             _id={_id}
             block={block}
             isChallenge={isChallenge}
           />
-          )
         ))}
       </TagBlockContainer>
       <HTMLViewer>
@@ -41,9 +38,13 @@ function DndInterface({
 }
 
 DndInterface.propTypes = {
-  tagBlocks: PropTypes.arrayOf(
-    PropTypes.shape(TagBlock.propTypes),
-  ).isRequired,
+  tagBlockContainer: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    tagName: PropTypes.string.isRequired,
+    childTrees: PropTypes.arrayOf(
+      PropTypes.shape(TagBlock.propTypes),
+    ).isRequired,
+  }).isRequired,
   boilerplate: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     childTrees: PropTypes.arrayOf(
@@ -69,7 +70,7 @@ const DndInterfaceWrapper = styled.div`
   grid-template-columns: 1fr 1fr;
 `;
 
-const TagBlockContainer = styled.div`
+const TagBlockContainer = styled(Droppable)`
   display: flex;
   flex-wrap: wrap;
   margin: 10px;

--- a/src/components/Puzzle/index.jsx
+++ b/src/components/Puzzle/index.jsx
@@ -16,7 +16,7 @@ import { MESSAGE } from "../../constants";
 function Puzzle({ notifyError, onFinish }) {
   const dispatch = useDispatch();
   const { id } = useParams();
-  const { challengeId, tagBlocks, isCompleted } = useSelector((state) => state.challenge);
+  const { challengeId, tagBlockContainer, isCompleted } = useSelector((state) => state.challenge);
   const boilerplate = useSelector((state) => state.challenge.boilerplate, compareChildTreeIds);
   const answer = useSelector((state) => state.challenge.answer, compareChildTreeIds);
   const isCorrect = compareChildTreeByBlockIds(boilerplate, answer);
@@ -65,7 +65,7 @@ function Puzzle({ notifyError, onFinish }) {
               )
               : (
                 <DndInterface
-                  tagBlocks={tagBlocks}
+                  tagBlockContainer={tagBlockContainer}
                   boilerplate={boilerplate}
                   onDrop={handleDrop}
                 />

--- a/src/components/Tutorial/index.jsx
+++ b/src/components/Tutorial/index.jsx
@@ -43,7 +43,7 @@ function Tutorial({ onFinish }) {
           <>
             <div>Mark Up Blocks에 오신 것을 환영합니다! 아래 태그 블록을 div 안으로 옮겨볼까요?</div>
             <WideDndInterface
-              tagBlocks={tutorialBlocks}
+              tagBlockContainer={{ _id: "tagBlockContainer", tagName: "div", childTrees: tutorialBlocks }}
               boilerplate={boilerplate}
               onDrop={handleDrop}
             />

--- a/src/components/Tutorial/sampleData.js
+++ b/src/components/Tutorial/sampleData.js
@@ -19,7 +19,7 @@ const sampleBlock = {
 
 const sampleBoilerplate = {
   _id: "tutorialBox",
-  block: { tagName: "div" },
+  block: { _id: "tutorialBoxBlock", tagName: "div" },
   childTrees: [],
 };
 

--- a/src/utils/selectData.js
+++ b/src/utils/selectData.js
@@ -26,8 +26,14 @@ function findBlockTreeById(root, _id) {
   return findBlockTree(root, (block) => block._id === _id);
 }
 
-function findTagBlockById(tagBlocks, _id) {
-  return tagBlocks.find((tagBlock) => tagBlock._id === _id);
+function findContainerByChildId(root, _id) {
+  if (!_id) {
+    return null;
+  }
+
+  return findBlockTree(root, (block) => block.childTrees.find(
+    (childBlock) => childBlock._id === _id,
+  ), _id);
 }
 
 function compareChildTreeIds(left, right) {
@@ -133,7 +139,7 @@ function findNextUncompletedChallenge(root, id) {
 export {
   findBlockTree,
   findBlockTreeById,
-  findTagBlockById,
+  findContainerByChildId,
   compareChildTreeIds,
   compareChildTreeByBlockIds,
   findChallengeById,


### PR DESCRIPTION
closes #17
아래와 같이 구조를 변경하였습니다.
- features/challenge
  - state의 tagBlocks를 tagBlockContainer로 대체하고, 기존 tagBlocks 데이터는 tagBlockContainer.childTrees에 위치시켰습니다.
  - tagBlock의 기본 컨테이너가 존재(tagBlockContainer)하므로 tagBlock의 hasUsed 속성은 필요하지 않아 삭제하였습니다.
  - 기존에 tagBlock 처리에서 필요했던 유틸함수 findTagBlockById를 현재 구조에 맞는 findContainerByChildId로 대체하였습니다.
- DndInterface/TagBlockContainer
  - Droppable을 wrapper tag로 사용해 HTMLViewer의 tagBlock을 다시 Drop 할 수 있도록 수정하였습니다.
  - Droppable에 className prop을 추가하였습니다.
