### PR TITLE
Fix issue35

### DIFF
--- a/src/components/Puzzle/DndInterface/DropContainer/index.jsx
+++ b/src/components/Puzzle/DndInterface/DropContainer/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import Draggable from "../Draggable";
 import Droppable from "../Droppable";
-import TagBlock from "../TagBlock";
+import { tagBlockSchema } from "../TagBlock";
 
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
@@ -57,7 +57,7 @@ DropContainer.propTypes = {
   _id: PropTypes.string.isRequired,
   tagName: PropTypes.string.isRequired,
   childTrees: PropTypes.arrayOf(
-    PropTypes.shape({ ...TagBlock.propTypes, containerId: null }),
+    PropTypes.shape(tagBlockSchema),
   ).isRequired,
   onDrop: PropTypes.func.isRequired,
 };

--- a/src/components/Puzzle/DndInterface/TagBlock/index.jsx
+++ b/src/components/Puzzle/DndInterface/TagBlock/index.jsx
@@ -27,7 +27,7 @@ function TagBlock({
     window.addEventListener("resize", handleGetPosition);
 
     if (ref?.current) {
-      handleGetPosition();
+      setPosition(calcPosition(ref?.current));
     }
 
     return () => window.removeEventListener("resize", handleGetPosition);

--- a/src/components/Puzzle/DndInterface/index.jsx
+++ b/src/components/Puzzle/DndInterface/index.jsx
@@ -14,14 +14,20 @@ function DndInterface({
   return (
     <DndInterfaceWrapper className={className}>
       <TagBlockContainer _id={TYPE.TAG_BLOCK_CONTAINER} onDrop={onDrop}>
-        {tagBlockContainer.childTrees.map(({ _id, isSubChallenge, block }) => (
-          <TagBlock
+        {tagBlockContainer.childTrees.map(({ _id, isSubChallenge, block }, index) => (
+          <Droppable
+            _id={TYPE.TAG_BLOCK_CONTAINER}
             key={_id}
-            _id={_id}
-            block={block}
-            isSubChallenge={isSubChallenge}
-            containerId={TYPE.TAG_BLOCK_CONTAINER}
-          />
+            index={index}
+            onDrop={onDrop}
+          >
+            <TagBlock
+              _id={_id}
+              block={block}
+              isSubChallenge={isSubChallenge}
+              containerId={TYPE.TAG_BLOCK_CONTAINER}
+            />
+          </Droppable>
         ))}
       </TagBlockContainer>
       <HTMLViewer>

--- a/src/components/Puzzle/DndInterface/index.jsx
+++ b/src/components/Puzzle/DndInterface/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-import TagBlock from "./TagBlock";
+import TagBlock, { tagBlockSchema } from "./TagBlock";
 import Droppable from "./Droppable";
 import DropContainer from "./DropContainer";
 
@@ -14,7 +14,9 @@ function DndInterface({
   return (
     <DndInterfaceWrapper className={className}>
       <TagBlockContainer _id={TYPE.TAG_BLOCK_CONTAINER} onDrop={onDrop}>
-        {tagBlockContainer.childTrees.map(({ _id, isSubChallenge, block }, index) => (
+        {tagBlockContainer.childTrees.map(({
+          _id, isSubChallenge, block, childTrees,
+        }, index) => (
           <Droppable
             _id={TYPE.TAG_BLOCK_CONTAINER}
             key={_id}
@@ -26,6 +28,7 @@ function DndInterface({
               block={block}
               isSubChallenge={isSubChallenge}
               containerId={TYPE.TAG_BLOCK_CONTAINER}
+              childTrees={childTrees}
             />
           </Droppable>
         ))}
@@ -46,13 +49,13 @@ DndInterface.propTypes = {
   tagBlockContainer: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     childTrees: PropTypes.arrayOf(
-      PropTypes.shape({ ...TagBlock.propTypes, containerId: null }),
+      PropTypes.shape(tagBlockSchema),
     ).isRequired,
   }).isRequired,
   boilerplate: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     childTrees: PropTypes.arrayOf(
-      PropTypes.shape({ ...TagBlock.propTypes, containerId: null }),
+      PropTypes.shape(tagBlockSchema),
     ).isRequired,
     block: PropTypes.shape({
       _id: PropTypes.string.isRequired,

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,4 +18,11 @@ const DRAGGABLE_TYPE = {
   CONTAINER: "container",
 };
 
-export { MESSAGE, TYPE, DRAGGABLE_TYPE };
+const NUMBER = {
+  DEBOUNCE_DELAY: 500,
+  PREVIEW_X_RANGE: 0.45,
+};
+
+export {
+  MESSAGE, TYPE, DRAGGABLE_TYPE, NUMBER,
+};

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -28,23 +28,20 @@ const challengeSlice = createSlice({
       const prevContainer = selectContainer(selectedSubChallenge, prevContainerId);
       const container = selectContainer(selectedSubChallenge, containerId);
       const blockTree = findBlockTreeById(prevContainer, itemId);
+      const itemIndex = index === -1 ? container.childTrees.length : index;
 
-      const isInvalidContainer = Boolean(findBlockTreeById(blockTree, container._id));
-      const isSameContainer = prevContainer._id === container._id;
+      const isInvalidContainer = !!findBlockTreeById(blockTree, container._id);
 
       if (isInvalidContainer) {
         return;
       }
 
+      prevContainer.childTrees = prevContainer.childTrees.filter((child) => child._id !== itemId);
       container.childTrees = [
-        ...container.childTrees.slice(0, index),
+        ...container.childTrees.slice(0, itemIndex),
         blockTree,
-        ...container.childTrees.slice(index),
+        ...container.childTrees.slice(itemIndex),
       ];
-
-      prevContainer.childTrees = prevContainer.childTrees.filter(
-        (child, childIndex) => child._id !== itemId || (isSameContainer && childIndex === index),
-      );
     },
   },
   extraReducers: {

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -63,7 +63,7 @@ const challengeSlice = createSlice({
       selectedSubChallenge.boilerplate = { ...selectedSubChallenge, childTrees: [] };
       selectedSubChallenge.tagBlockContainer = {
         _id: TYPE.TAG_BLOCK_CONTAINER,
-        childTrees: generateBlocks(selectedSubChallenge, true),
+        childTrees: generateBlocks(selectedSubChallenge),
       };
 
       if (payload.hasFetched) {

--- a/src/helpers/dataFormatters.js
+++ b/src/helpers/dataFormatters.js
@@ -1,3 +1,5 @@
+import { NUMBER } from "../constants";
+
 function convertCamelToKebab(string) {
   return [...string]
     .map((char, index) => (
@@ -7,26 +9,20 @@ function convertCamelToKebab(string) {
     .join("");
 }
 
-function calcPosition(ref) {
-  const result = {
-    top: 0,
-    left: 0,
-  };
+function calcPosition(prevPosition, newPosition) {
+  const { top, left } = prevPosition;
+  const { bottom, right, height } = newPosition;
 
-  if (!ref) {
-    return result;
+  const result = { top, left };
+  const isXOverflowed = left + right > (window.innerWidth * NUMBER.PREVIEW_X_RANGE);
+  const isYOverflowed = top + bottom > window.innerHeight;
+
+  if (isXOverflowed) {
+    result.left -= left + right - (window.innerWidth * NUMBER.PREVIEW_X_RANGE);
   }
 
-  const {
-    top, left, width, height,
-  } = ref.getBoundingClientRect();
-
-  if (left + width > (window.innerWidth / 2)) {
-    result.left -= (left + width - (window.innerWidth / 2));
-  }
-
-  if (top + height > window.innerHeight) {
-    result.top -= height;
+  if (isYOverflowed) {
+    result.top = -height;
   }
 
   return result;

--- a/src/helpers/dataFormatters.js
+++ b/src/helpers/dataFormatters.js
@@ -28,7 +28,14 @@ function calcPosition(prevPosition, newPosition) {
   return result;
 }
 
+function formatTagName(isContainer, tagName, text) {
+  return isContainer
+    ? `<${tagName} />`
+    : `<${tagName}>${text}</${tagName}>`;
+}
+
 export {
   convertCamelToKebab,
   calcPosition,
+  formatTagName,
 };

--- a/src/helpers/tagBlockGenerators.js
+++ b/src/helpers/tagBlockGenerators.js
@@ -1,21 +1,18 @@
-function generateBlocks(elementTree, isRecursive = false) {
+function generateBlocks(elementTree) {
   const queue = [...elementTree.childTrees];
   const blocks = [];
 
   while (queue.length) {
     const currentNode = queue.shift();
 
-    if (currentNode.isSubChallenge) {
-      blocks.push(currentNode);
-    } else {
+    if (!currentNode.isSubChallenge && currentNode.block.isContainer) {
       blocks.push({
         ...currentNode,
         childTrees: [],
       });
-
-      if (isRecursive && currentNode.childTrees) {
-        queue.push(...currentNode.childTrees);
-      }
+      queue.push(...currentNode.childTrees);
+    } else {
+      blocks.push(currentNode);
     }
   }
 

--- a/src/theme/global.js
+++ b/src/theme/global.js
@@ -7,6 +7,7 @@ const GlobalStyle = createGlobalStyle`
   html, body, #root {
     width: 100%;
     height: 100%;
+    overflow: hidden;
   }
 
   a {


### PR DESCRIPTION
closes #35 
해당 이슈 관련 태스크를 처리하였습니다.
- TagBlockContainer에서 제자리 드롭시 블록 사라지는 오류 해결
  - TagBlockContainer의 onDrop시 index가 지정되지 않아 기본값인 -1이 적용되어 발생한 오류입니다.
    - 인덱스가 -1인 경우 마지막 인덱스를 갖도록 수정하였습니다.
    - 인덱스가 보장되니 기존 컨테이너에서 item을 먼저 삭제 후 새 컨테이너에 추가할 수 있게 되어, challenge reducer에서 prevContainer filter 로직이 간소화되었습니다.
  - TagBlock들을 Droppable로 감싸 TagBlockContainer 내부에서도 순서를 변경할 수 있도록 수정하였습니다.
- preview에 isSubChallenge 태그인 경우 childTrees까지 포함해서 렌더링
  - isContainer 태그인 경우 가상의 childTrees 포함하였습니다.
  - childTrees 정보를 처리하기 위해 TabBlock 컴포넌트의 propTypes와 src/helpers/generateBlocks를 수정하였습니다.
- 윈도우 resize시 preview 위치 반영이 안 되는 오류 해결
  - calcPosition 함수에서 초기값이 매번 top: 0, left: 0으로 지정되어 발생한 오류입니다.
    - 함수 호출 시 state에 저장된 기존 top, left 값을 함께 전달하도록 수정하였습니다.
  - resize 이벤트리스너를 ResizeObserver로 대체하였습니다.