### PR TITLE
Modify: css layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -116,5 +116,5 @@ const AppWrapper = styled.div`
   display: grid;
   width: 100%;
   height: 100%;
-  grid-template-rows: 50px 4fr 3fr;
+  grid-template-rows: 50px 1fr;
 `;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -85,8 +85,12 @@ const HeaderWrapper = styled.header`
 
 const Title = styled.h2`
   margin: 10px;
-  font-size: 1.8rem;
+  font-size: 1.5rem;
   cursor: pointer;
+
+  @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
+    font-size: 1.2rem;
+  }
 `;
 
 const Nav = styled.nav`
@@ -103,7 +107,7 @@ const OpenButton = styled(Button)`
   color: ${({ theme }) => theme.color.main};
   background-color: ${({ theme }) => theme.color.inner};
   border: none;
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.border.radius.container};
   cursor: pointer;
 
   &:hover {
@@ -118,7 +122,7 @@ const ListWrapper = styled.ol`
   padding: 5px;
   background-color: ${({ theme }) => theme.color.inner};
   border: 2px solid ${({ theme }) => theme.color.main};
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.border.radius.container};
   box-shadow: 2px 2px 3px gray;
 `;
 

--- a/src/components/ModalTemplate/FinishPopup/index.jsx
+++ b/src/components/ModalTemplate/FinishPopup/index.jsx
@@ -42,7 +42,7 @@ const NextStage = styled.div`
     border-top: 10px solid transparent;
     border-bottom: 10px solid transparent;
     border-left: 18px solid ${({ color }) => color};
-    border-radius: 2px;
+    border-radius: ${({ theme }) => theme.border.radius.container};
   }
 
   .next-stage-text {

--- a/src/components/Puzzle/Display/index.jsx
+++ b/src/components/Puzzle/Display/index.jsx
@@ -5,13 +5,14 @@ import styled from "styled-components";
 import ElementBlock from "./ElementBlock";
 import { TYPE } from "../../../constants";
 
-function Display({ boilerplate, elementTree, isDone }) {
-  const pages = isDone
-    ? [{ ...boilerplate, key: TYPE.BOILERPLATE }]
-    : [{ ...boilerplate, key: TYPE.BOILERPLATE }, { ...elementTree, key: TYPE.ELEMENT_TREE }];
+function Display({ boilerplate, elementTree }) {
+  const pages = [
+    { ...boilerplate, key: TYPE.BOILERPLATE },
+    { ...elementTree, key: TYPE.ELEMENT_TREE },
+  ];
 
   return (
-    <Container hasSingleChild={isDone}>
+    <Container>
       {pages.map(({
         _id, key, block, childTrees,
       }) => (
@@ -30,15 +31,20 @@ function Display({ boilerplate, elementTree, isDone }) {
 Display.propTypes = {
   boilerplate: PropTypes.shape(ElementBlock.propTypes).isRequired,
   elementTree: PropTypes.shape(ElementBlock.propTypes).isRequired,
-  isDone: PropTypes.bool.isRequired,
 };
 
 export default Display;
 
 const Container = styled.div`
   display: grid;
-  grid-template-columns: ${({ hasSingleChild }) => (hasSingleChild ? "1fr" : "1fr 1fr")};
-  margin: ${({ hasSingleChild }) => (hasSingleChild ? "0 auto" : "0")};
+  width: 100%;
+  height: 100%;
+  grid-template-columns: 1fr 1fr;
+
+  @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
+    grid-template-columns: auto;
+    grid-template-rows: 1fr 1fr;
+  }
 `;
 
 const PageWrapper = styled.div`
@@ -46,5 +52,11 @@ const PageWrapper = styled.div`
   margin: 10px;
   justify-content: center;
   align-items: center;
-  border: ${({ theme }) => theme.border.page};
+  border: ${({ theme }) => theme.border.container};
+  border-radius: ${({ theme }) => theme.border.radius.container};
+
+  @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
+    max-height: 300px;
+    overflow: auto;
+  }
 `;

--- a/src/components/Puzzle/DndInterface/TagBlock/index.jsx
+++ b/src/components/Puzzle/DndInterface/TagBlock/index.jsx
@@ -111,7 +111,7 @@ const Preview = styled.div`
   padding: 10px;
   background-color: darkgray;
   border: 1px solid ${({ theme }) => theme.color.main};
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.border.radius.container};
   justify-content: start;
   transition: all 0.25s;
 
@@ -120,7 +120,7 @@ const Preview = styled.div`
     margin: auto;
     padding: 10px;
     background-color: white;
-    border-radius: 4px;
+    border-radius: ${({ theme }) => theme.border.radius.container};
     justify-content: center;
     align-items: center;
   }

--- a/src/components/Puzzle/DndInterface/index.jsx
+++ b/src/components/Puzzle/DndInterface/index.jsx
@@ -13,26 +13,28 @@ function DndInterface({
 }) {
   return (
     <DndInterfaceWrapper className={className}>
-      <TagBlockContainer _id={TYPE.TAG_BLOCK_CONTAINER} onDrop={onDrop}>
-        {tagBlockContainer.childTrees.map(({
-          _id, isSubChallenge, block, childTrees,
-        }, index) => (
-          <Droppable
-            _id={TYPE.TAG_BLOCK_CONTAINER}
-            key={_id}
-            index={index}
-            onDrop={onDrop}
-          >
-            <TagBlock
-              _id={_id}
-              block={block}
-              isSubChallenge={isSubChallenge}
-              containerId={TYPE.TAG_BLOCK_CONTAINER}
-              childTrees={childTrees}
-            />
-          </Droppable>
-        ))}
-      </TagBlockContainer>
+      <Droppable className="tag-block-container-droppable" _id={TYPE.TAG_BLOCK_CONTAINER} onDrop={onDrop}>
+        <TagBlockContainer>
+          {tagBlockContainer.childTrees.map(({
+            _id, isSubChallenge, block, childTrees,
+          }, index) => (
+            <Droppable
+              _id={TYPE.TAG_BLOCK_CONTAINER}
+              key={_id}
+              index={index}
+              onDrop={onDrop}
+            >
+              <TagBlock
+                _id={_id}
+                block={block}
+                isSubChallenge={isSubChallenge}
+                containerId={TYPE.TAG_BLOCK_CONTAINER}
+                childTrees={childTrees}
+              />
+            </Droppable>
+          ))}
+        </TagBlockContainer>
+      </Droppable>
       <HTMLViewer>
         <DropContainer
           _id={boilerplate._id}
@@ -74,21 +76,36 @@ export default DndInterface;
 
 const DndInterfaceWrapper = styled.div`
   display: grid;
+  width: 100%;
+  height: 100%;
   grid-template-columns: 1fr 1fr;
+
+  @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  .tag-block-container-droppable {
+    display: flex;
+    margin: 10px;
+    justify-content: center;
+    align-items: center;
+    border: ${({ theme }) => theme.border.container};
+    border-radius: ${({ theme }) => theme.border.radius.container};
+  }
 `;
 
-const TagBlockContainer = styled(Droppable)`
+const TagBlockContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  margin: 10px;
   justify-content: center;
   align-items: center;
-  border: ${({ theme }) => theme.border.page};
 `;
 
 const HTMLViewer = styled.div`
   display: grid;
   align-items: center;
   margin: 10px;
-  border: ${({ theme }) => theme.border.page};
+  border: ${({ theme }) => theme.border.container};
+  border-radius: ${({ theme }) => theme.border.radius.container};
 `;

--- a/src/components/Puzzle/index.jsx
+++ b/src/components/Puzzle/index.jsx
@@ -39,14 +39,14 @@ function Puzzle({ notifyError, onFinish }) {
     <PuzzleWrapper>
       {isLoaded && String(selectedIndex) === index
         ? (
-          <div>
+          <>
             <Display boilerplate={boilerplate} elementTree={elementTree} />
             <DndInterface
               tagBlockContainer={tagBlockContainer}
               boilerplate={boilerplate}
               onDrop={handleDrop}
             />
-          </div>
+          </>
         )
         : <Loading />}
       {isCompleted && <FinishPopup onClick={() => onFinish(id)} />}
@@ -63,5 +63,12 @@ export default Puzzle;
 
 const PuzzleWrapper = styled.div`
   display: grid;
-  grid-template-rows: 4fr 3fr;
+  width: 100%;
+  height: 100%;
+  margin-bottom: 20px;
+  grid-template-rows: 2fr 1fr;
+
+  @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
+    grid-template-rows: unset;
+  }
 `;

--- a/src/components/Tutorial/index.jsx
+++ b/src/components/Tutorial/index.jsx
@@ -55,6 +55,7 @@ export default Tutorial;
 const WideDndInterface = styled(DndInterface)`
   width: 100%;
   height: 100%;
+  margin-top: 20px;
 `;
 
 const Guide = styled.div`

--- a/src/components/shared/Modal/index.jsx
+++ b/src/components/shared/Modal/index.jsx
@@ -60,6 +60,6 @@ const ModalWrapper = styled.div`
   align-items: center;
   padding: 20px;
   text-align: center;
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.border.radius.container};
   background-color: ${({ theme }) => theme.color.inner};
 `;

--- a/src/theme/global.js
+++ b/src/theme/global.js
@@ -7,7 +7,6 @@ const GlobalStyle = createGlobalStyle`
   html, body, #root {
     width: 100%;
     height: 100%;
-    overflow: hidden;
   }
 
   a {

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -8,12 +8,22 @@ const color = {
 };
 
 const border = {
-  page: "2px solid #FBC00E",
+  container: "2px solid #FBC00E",
+  radius: {
+    container: "4px",
+  },
+};
+
+const screenSize = {
+  maxWidth: {
+    mobile: "600px",
+  },
 };
 
 const theme = {
   color,
   border,
+  screenSize,
 };
 
 export default theme;


### PR DESCRIPTION
![cssLayout](https://user-images.githubusercontent.com/60309558/137240090-71293a00-44dd-4c14-a6f5-49f91e32df25.gif)
- 레이아웃 관련 수정하였습니다. 작은 화면에서는 세로로 컨테이너들이 출력됩니다.
- finishPopup을 추가하면서 사용하지 않게 된 Display 컴포넌트의 isDone 프로퍼티를 정리하였습니다.