### PR TITLE
Add: support for mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5826,6 +5826,11 @@
         "redux": "^4.1.1"
       }
     },
+    "dnd-multi-backend": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/dnd-multi-backend/-/dnd-multi-backend-6.0.0.tgz",
+      "integrity": "sha512-qfUO4V0IACs24xfE9m9OUnwIzoL+SWzSiFbKVIHE0pFddJeZ93BZOdHS1XEYr8X3HNh+CfnfjezXgOMgjvh74g=="
+    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -15048,6 +15053,33 @@
       "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.0.2.tgz",
       "integrity": "sha512-QgN6rYrOm4UUj6tIvN8ovImu6uP48xBXF2rzVsp6tvj6d5XQ7OjHI4SJ/ZgGobOneRAU3WCX4f8DGCYx0tuhlw==",
       "requires": {
+        "dnd-core": "14.0.1"
+      }
+    },
+    "react-dnd-multi-backend": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-dnd-multi-backend/-/react-dnd-multi-backend-6.0.2.tgz",
+      "integrity": "sha512-SwpqRv0HkJYu244FbHf9NbvGzGy14Ir9wIAhm909uvOVaHgsOq6I1THMSWSgpwUI31J3Bo5uS19tuvGpVPjzZw==",
+      "requires": {
+        "dnd-multi-backend": "^6.0.0",
+        "prop-types": "^15.7.2",
+        "react-dnd-preview": "^6.0.2"
+      }
+    },
+    "react-dnd-preview": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-dnd-preview/-/react-dnd-preview-6.0.2.tgz",
+      "integrity": "sha512-F2+uK4Be+q+7mZfNh9kaZols7wp1hX6G7UBTVaTpDsBpMhjFvY7/v7odxYSerSFBShh23MJl33a4XOVRFj1zoQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
+    "react-dnd-touch-backend": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-14.1.1.tgz",
+      "integrity": "sha512-ITmfzn3fJrkUBiVLO6aJZcnu7T8C+GfwZitFryGsXKn5wYcUv+oQBeh9FYcMychmVbDdeUCfvEtTk9O+DKmAaw==",
+      "requires": {
+        "@react-dnd/invariant": "^2.0.0",
         "dnd-core": "14.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "react": "^17.0.2",
     "react-dnd": "^14.0.4",
     "react-dnd-html5-backend": "^14.0.2",
+    "react-dnd-multi-backend": "^6.0.2",
+    "react-dnd-touch-backend": "^14.1.1",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.5",
     "react-router-dom": "^5.3.0",

--- a/src/components/Puzzle/DndInterface/TagBlock/index.jsx
+++ b/src/components/Puzzle/DndInterface/TagBlock/index.jsx
@@ -19,6 +19,13 @@ function TagBlock({
       isSubChallenge, block, childTrees, position,
     });
   };
+  const handleClick = () => {
+    const position = ref?.current ? ref.current.getBoundingClientRect() : {};
+
+    onClick({
+      _id, isSubChallenge, block, childTrees, position,
+    });
+  };
 
   return (
     <TagBlockWrapper
@@ -26,7 +33,7 @@ function TagBlock({
       onMouseOver={handleMouseOver}
       onMouseOut={onMouseOut}
       ref={ref}
-      onClick={onClick}
+      onClick={handleClick}
     >
       <Draggable
         _id={_id}

--- a/src/components/Puzzle/DndInterface/index.jsx
+++ b/src/components/Puzzle/DndInterface/index.jsx
@@ -46,6 +46,10 @@ function DndInterface({
     handlePreviewClick();
     onDrop(params);
   };
+  const handleTagBlockClick = (hovered) => {
+    setIsClicked((prev) => !prev);
+    setHoveredBlock((prevHovered) => (prevHovered?._id === hovered._id ? null : hovered));
+  };
 
   return (
     <DndInterfaceWrapper className={className}>
@@ -84,7 +88,7 @@ function DndInterface({
                   childTrees={childTrees}
                   onMouseOver={handleBlockHovered}
                   onMouseOut={handleBlockUnhovered}
-                  onClick={() => setIsClicked((prev) => !prev)}
+                  onClick={handleTagBlockClick}
                 />
               </Droppable>
             ))}

--- a/src/helpers/dataFormatters.js
+++ b/src/helpers/dataFormatters.js
@@ -17,6 +17,7 @@ function calcPosition(tagBlockPosition, previewPosition) {
 
   if (overflowX > 0) {
     result.left -= overflowX;
+    result.left = result.left < 0 ? 0 : result.left;
   }
 
   result.top = -height;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,14 +3,15 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
 import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
+import MultiBackend from "react-dnd-multi-backend";
+import HTML5toTouch from "react-dnd-multi-backend/dist/esm/HTML5toTouch";
 import App from "./App";
 import store from "./app/store";
 
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <DndProvider backend={HTML5Backend}>
+      <DndProvider backend={MultiBackend} options={HTML5toTouch}>
         <Router>
           <App />
         </Router>


### PR DESCRIPTION
closes #34 
- react-dnd-multi-backend 라이브러리를 dependency에 추가하고, index의 Provider를 교체하였습니다.
- 모바일 대응을 위해 TagBlock에서 터치로 Preview를 열 수 있도록 수정하고, Preview 위치를 조정하였습니다.