### PR TITLE
Fix issue53 (mobile interface)

### DIFF
--- a/src/components/Challenge/Display/index.jsx
+++ b/src/components/Challenge/Display/index.jsx
@@ -15,8 +15,8 @@ function Display({ boilerplate, elementTree }) {
     <Container>
       {pages.map(({
         _id, key, block, childTrees,
-      }) => (
-        <PageWrapper key={key}>
+      }, index) => (
+        <PageWrapper key={key} index={index}>
           <ElementBlock
             _id={_id}
             block={block}
@@ -59,5 +59,6 @@ const PageWrapper = styled.div`
   @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
     max-height: 300px;
     overflow: auto;
+    order: ${({ index }) => -index};
   }
 `;

--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useDragLayer } from "react-dnd";
+import styled from "styled-components";
+
+import { getItemStyles } from "../../../../helpers/dataFormatters";
+
+function CustomDragLayer() {
+  const {
+    isDragging, item, initialOffset, currentOffset,
+  } = useDragLayer((monitor) => ({
+    item: monitor.getItem(),
+    itemType: monitor.getItemType(),
+    initialOffset: monitor.getInitialSourceClientOffset(),
+    currentOffset: monitor.getSourceClientOffset(),
+    isDragging: monitor.isDragging(),
+  }));
+
+  if (!isDragging) {
+    return null;
+  }
+
+  return (
+    <Layer>
+      <span style={getItemStyles(initialOffset, currentOffset)} className="dragging-content">{item.content}</span>
+    </Layer>
+  );
+}
+
+export default CustomDragLayer;
+
+const Layer = styled.div`
+  position: fixed;
+  display: flex;
+  z-index: 1;
+  pointer-events: none;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+
+  .dragging-content {
+    height: 25px;
+  }
+`;

--- a/src/components/Challenge/DndInterface/Draggable/index.jsx
+++ b/src/components/Challenge/DndInterface/Draggable/index.jsx
@@ -1,22 +1,28 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
+import { getEmptyImage } from "react-dnd-html5-backend";
 import { useDrag } from "react-dnd";
 import styled from "styled-components";
 
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function Draggable({
-  children, _id, type, containerId,
+  children, _id, type, containerId, content,
 }) {
-  const [, dragRef] = useDrag(
-    () => ({
-      type,
-      item: { itemId: _id, prevContainerId: containerId },
-    }),
-  );
+  const [{ isDragging }, dragRef, dragPreview] = useDrag(() => ({
+    type,
+    item: { itemId: _id, prevContainerId: containerId, content },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  }));
+
+  useEffect(() => {
+    dragPreview(getEmptyImage(), { captureDraggingState: true });
+    // disable default preview for using custom drag layer. reference https://react-dnd.github.io/react-dnd/examples/drag-around/custom-drag-layer
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
-    <DraggableWrapper ref={dragRef}>
+    <DraggableWrapper ref={dragRef} className={isDragging ? "dragging" : ""}>
       {children}
     </DraggableWrapper>
   );
@@ -30,6 +36,7 @@ Draggable.propTypes = {
   _id: PropTypes.string.isRequired,
   type: PropTypes.oneOf(Object.values(DRAGGABLE_TYPE)).isRequired,
   containerId: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
 };
 
 export default Draggable;
@@ -38,5 +45,5 @@ const DraggableWrapper = styled.div`
   margin: 1px 20px;
   padding: 2px;
   cursor: pointer;
-  border-radius: ${({ theme }) => theme.border.radius.container}
+  border-radius: ${({ theme }) => theme.border.radius.container};
 `;

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -9,7 +9,9 @@ import { tagBlockSchema } from "../TagBlock";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropContainer({
-  _id, tagName, childTrees, onDrop, className, droppableClassName, droppableHoveredClassName,
+  _id, tagName, childTrees,
+  onDrop, onClick,
+  className, droppableClassName, droppableHoveredClassName,
 }) {
   function getTextValue(child) {
     return child.isSubChallenge
@@ -26,6 +28,7 @@ function DropContainer({
           _id={_id}
           index={0}
           onDrop={onDrop}
+          onClick={onClick}
           className={`droppable ${droppableClassName}`}
           hoveredClassName={`droppable ${droppableHoveredClassName}`}
         >
@@ -46,6 +49,7 @@ function DropContainer({
                     childTrees={child.childTrees}
                     tagName={child.block.tagName}
                     onDrop={onDrop}
+                    onClick={onClick}
                     droppableClassName={droppableClassName}
                     droppableHoveredClassName={droppableHoveredClassName}
                   />
@@ -56,6 +60,7 @@ function DropContainer({
               _id={_id}
               index={index + 1}
               onDrop={onDrop}
+              onClick={onClick}
               className={`droppable ${droppableClassName}`}
               hoveredClassName={`droppable ${droppableHoveredClassName}`}
             >
@@ -79,6 +84,7 @@ DropContainer.propTypes = {
     }),
   ).isRequired,
   onDrop: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   droppableClassName: PropTypes.string,
   droppableHoveredClassName: PropTypes.string,

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -5,23 +5,35 @@ import styled from "styled-components";
 import Draggable from "../Draggable";
 import Droppable from "../Droppable";
 import { tagBlockSchema } from "../TagBlock";
+import Button from "../../../shared/Button";
 
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropContainer({
-  _id, tagName, childTrees,
-  onDrop, onClick,
+  _id, tagName, childTrees, containerId, selectedTagId,
+  onDrop, onClick, onBlockClick,
   className, droppableClassName, droppableHoveredClassName,
 }) {
   function getTextValue(child) {
     return child.isSubChallenge
       ? `<${child.block.tagName} />`
-      : `<${child.block.tagName}>${child.block.property.text}</${child.block.tagName}>`;
+      : `<${child.block.tagName}>${child.block.property.text || ""}</${child.block.tagName}>`;
   }
+
+  const handleTagClick = () => {
+    onBlockClick({ _id, containerId, isClicked: true });
+  };
 
   return (
     <DropContainerWrapper className={className}>
-      <span key="open" className="tag-text parent-tag">{`<${tagName}>`}</span>
+      <div className="tag-text">
+        <TagButton
+          key="open"
+          className={`parent-tag ${selectedTagId === _id ? "selected-tag" : ""}`}
+          onClick={handleTagClick}
+          value={`<${tagName}>`}
+        />
+      </div>
       <>
         <Droppable
           key={_id}
@@ -52,9 +64,24 @@ function DropContainer({
                     onClick={onClick}
                     droppableClassName={droppableClassName}
                     droppableHoveredClassName={droppableHoveredClassName}
+                    onBlockClick={onBlockClick}
+                    containerId={_id}
+                    selectedTagId={selectedTagId}
                   />
                 )
-                : <span className={`tag-text ${child.isCorrect ? "correct" : "wrong"}`}>{getTextValue(child)}</span>}
+                : (
+                  <div className="tag-text">
+                    <TagButton
+                      className={`${child.isCorrect ? "correct" : "wrong"} ${selectedTagId === child._id ? "selected-tag" : ""}`}
+                      value={getTextValue(child)}
+                      onClick={() => onBlockClick({
+                        _id: child._id,
+                        containerId: _id,
+                        isClicked: true,
+                      })}
+                    />
+                  </div>
+                )}
             </Draggable>
             <Droppable
               _id={_id}
@@ -69,14 +96,23 @@ function DropContainer({
           </div>
         ))}
       </>
-      <span key="close" className="tag-text parent-tag">{`</${tagName}>`}</span>
+      <div className="tag-text">
+        <TagButton
+          key="close"
+          className={`parent-tag ${selectedTagId === _id ? "selected-tag" : ""}`}
+          onClick={handleTagClick}
+          value={`</${tagName}>`}
+        />
+      </div>
     </DropContainerWrapper>
   );
 }
 
 DropContainer.propTypes = {
   _id: PropTypes.string.isRequired,
+  containerId: PropTypes.string.isRequired,
   tagName: PropTypes.string.isRequired,
+  selectedTagId: PropTypes.string,
   childTrees: PropTypes.arrayOf(
     PropTypes.shape({
       ...tagBlockSchema,
@@ -85,12 +121,14 @@ DropContainer.propTypes = {
   ).isRequired,
   onDrop: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  onBlockClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   droppableClassName: PropTypes.string,
   droppableHoveredClassName: PropTypes.string,
 };
 
 DropContainer.defaultProps = {
+  selectedTagId: "",
   className: "",
   droppableClassName: "",
   droppableHoveredClassName: "",
@@ -106,4 +144,12 @@ const DropContainerWrapper = styled.div`
   .parent-tag {
     color: ${({ theme }) => theme.color.parentTag};
   }
+
+  .selected-tag {
+    color: ${({ theme }) => theme.color.point};
+  }
+`;
+
+const TagButton = styled(Button)`
+  position: relative;
 `;

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -37,6 +37,7 @@ function DropContainer({
               _id={child._id}
               type={child.block.isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
               containerId={_id}
+              content={getTextValue(child)}
             >
               {child.block.isContainer && !child.isSubChallenge
                 ? (

--- a/src/components/Challenge/DndInterface/Droppable/index.jsx
+++ b/src/components/Challenge/DndInterface/Droppable/index.jsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function Droppable({
-  children, _id, index, onDrop, className, hoveredClassName,
+  children, _id, index, onDrop, onClick, className, hoveredClassName,
 }) {
   const [{ hovered }, dropRef] = useDrop(() => ({
     accept: Object.values(DRAGGABLE_TYPE),
@@ -28,10 +28,15 @@ function Droppable({
     },
   }), [_id, index]);
 
+  const handleClick = () => {
+    onClick({ containerId: _id, index });
+  };
+
   return (
     <DroppableWrapper
       className={hovered ? hoveredClassName : className}
       ref={dropRef}
+      onClick={handleClick}
     >
       {children}
     </DroppableWrapper>
@@ -46,6 +51,7 @@ Droppable.propTypes = {
   ]).isRequired,
   index: PropTypes.number,
   onDrop: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   hoveredClassName: PropTypes.string,
 };
@@ -63,4 +69,5 @@ const DroppableWrapper = styled.div`
   margin: 1px 0;
   padding: 3px 0;
   align-content: space-between;
+  cursor: pointer;
 `;

--- a/src/components/Challenge/DndInterface/TagBlock/index.jsx
+++ b/src/components/Challenge/DndInterface/TagBlock/index.jsx
@@ -16,7 +16,7 @@ function TagBlock({
     const position = ref?.current ? ref.current.getBoundingClientRect() : {};
 
     onMouseOver({
-      isSubChallenge, block, childTrees, position,
+      _id, isSubChallenge, block, childTrees, position,
     });
   };
   const handleClick = () => {
@@ -28,21 +28,22 @@ function TagBlock({
   };
 
   return (
-    <TagBlockWrapper
-      className={`swing ${className}`}
-      onMouseOver={handleMouseOver}
-      onMouseOut={onMouseOut}
-      ref={ref}
-      onClick={handleClick}
+    <Draggable
+      _id={_id}
+      type={isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
+      containerId={containerId}
+      content={content}
     >
-      <Draggable
-        _id={_id}
-        type={isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
-        containerId={containerId}
+      <TagBlockWrapper
+        className={className}
+        onMouseOver={handleMouseOver}
+        onMouseOut={onMouseOut}
+        ref={ref}
+        onClick={handleClick}
       >
         <span>{content}</span>
-      </Draggable>
-    </TagBlockWrapper>
+      </TagBlockWrapper>
+    </Draggable>
   );
 }
 
@@ -85,7 +86,7 @@ TagBlock.defaultProps = {
 export default TagBlock;
 
 const TagBlockWrapper = styled.div`
+  padding: 3px 20px;
   border-radius: 10px;
   border: 1px solid ${({ theme }) => theme.color.point};
-  margin: 10px;
 `;

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -151,7 +151,7 @@ const DndInterfaceWrapper = styled.div`
 
   @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
+    grid-auto-flow: row;
   }
 
   .tag-block-container-droppable {

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -45,6 +45,22 @@ function DndInterface({
     handlePreviewClick();
     onDrop(params);
   };
+  const handleDroppableClick = (params) => {
+    const { containerId, index } = params;
+
+    if (!selectedBlock || !selectedBlock.isClicked) {
+      return;
+    }
+
+    if (containerId === TYPE.TAG_BLOCK_CONTAINER) {
+      return;
+    }
+
+    onDrop({
+      itemId: selectedBlock._id, containerId, index, prevContainerId: TYPE.TAG_BLOCK_CONTAINER,
+    });
+    setSelectedBlock(null);
+  };
   const handleBlockClick = (selected) => {
     setSelectedBlock((prevSelected) => {
       if (prevSelected?._id === selected?._id && prevSelected.isClicked) {
@@ -63,6 +79,7 @@ function DndInterface({
         className="tag-block-container-droppable"
         hoveredClassName="tag-block-container-droppable"
         onDrop={handleDrop}
+        onClick={handleDroppableClick}
       >
         {selectedBlock && (
           <Preview
@@ -84,6 +101,7 @@ function DndInterface({
                 key={_id}
                 index={index}
                 onDrop={handleDrop}
+                onClick={handleDroppableClick}
               >
                 <TagBlock
                   _id={_id}
@@ -108,6 +126,7 @@ function DndInterface({
           childTrees={boilerplate.childTrees}
           tagName={boilerplate.block.tagName}
           onDrop={handleDrop}
+          onClick={handleDroppableClick}
           droppableClassName={selectedBlock ? "drop-guide" : ""}
           droppableHoveredClassName="selected"
         />

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -20,15 +20,29 @@ function DndInterface({
     }
 
     const {
-      _id, isSubChallenge, block, childTrees, position,
+      _id, isSubChallenge, block, childTrees, position, isClicked, containerId,
     } = selected;
+    const data = {
+      _id,
+      isSubChallenge,
+      block,
+      childTrees,
+      position,
+      isClicked,
+      containerId: containerId || TYPE.TAG_BLOCK_CONTAINER,
+    };
 
     if (!position) {
+      setSelectedBlock({
+        ...data,
+        enablePreview: false,
+      });
       return;
     }
 
     setSelectedBlock({
-      _id, isSubChallenge, block, childTrees, position,
+      ...data,
+      enablePreview: true,
     });
   };
   const handleBlockUnselect = () => {
@@ -52,12 +66,8 @@ function DndInterface({
       return;
     }
 
-    if (containerId === TYPE.TAG_BLOCK_CONTAINER) {
-      return;
-    }
-
     onDrop({
-      itemId: selectedBlock._id, containerId, index, prevContainerId: TYPE.TAG_BLOCK_CONTAINER,
+      itemId: selectedBlock._id, containerId, index, prevContainerId: selectedBlock.containerId,
     });
     setSelectedBlock(null);
   };
@@ -67,7 +77,23 @@ function DndInterface({
         return null;
       }
 
-      return { ...selected, isClicked: true };
+      const {
+        _id, isSubChallenge, block, childTrees, position, containerId,
+      } = selected;
+      const data = {
+        _id,
+        isSubChallenge,
+        block,
+        childTrees,
+        position,
+        containerId: containerId || TYPE.TAG_BLOCK_CONTAINER,
+      };
+
+      if (!position) {
+        return { ...data, isClicked: true, enablePreview: false };
+      }
+
+      return { ...data, isClicked: true, enablePreview: true };
     });
   };
 
@@ -81,7 +107,7 @@ function DndInterface({
         onDrop={handleDrop}
         onClick={handleDroppableClick}
       >
-        {selectedBlock && (
+        {selectedBlock?.enablePreview ? (
           <Preview
             isSubChallenge={selectedBlock.isSubChallenge}
             block={selectedBlock.block}
@@ -90,7 +116,7 @@ function DndInterface({
             position={selectedBlock.position}
             onClick={handlePreviewClick}
           />
-        )}
+        ) : null}
         <TagBlockContainer>
           <>
             {tagBlockContainer.childTrees.map(({
@@ -127,8 +153,11 @@ function DndInterface({
           tagName={boilerplate.block.tagName}
           onDrop={handleDrop}
           onClick={handleDroppableClick}
+          onBlockClick={handleBlockSelect}
           droppableClassName={selectedBlock ? "drop-guide" : ""}
           droppableHoveredClassName="selected"
+          containerId={TYPE.BOILERPLATE}
+          selectedTagId={selectedBlock?._id}
         />
       </HTMLViewer>
     </DndInterfaceWrapper>
@@ -205,6 +234,10 @@ const HTMLViewer = styled.div`
   border: ${({ theme }) => theme.border.container};
   border-radius: ${({ theme }) => theme.border.radius.container};
   counter-reset: line;
+
+  .dragging * {
+    color: ${({ theme }) => theme.color.point};
+  }
 
   .tag-text::before {
     position: absolute;

--- a/src/components/Challenge/index.jsx
+++ b/src/components/Challenge/index.jsx
@@ -24,7 +24,12 @@ function Challenge() {
     itemId, containerId, index: containerIndex, prevContainerId,
   }) => {
     dispatch(addChildTree({
-      itemId, containerId, index: containerIndex, prevContainerId, stageId: stage._id,
+      challengeIndex: Number(index),
+      itemId,
+      containerId,
+      containerIndex,
+      prevContainerId,
+      stageId: stage._id,
     }));
   };
   const handleReset = () => dispatch(resetStage(stage._id));

--- a/src/components/Challenge/index.jsx
+++ b/src/components/Challenge/index.jsx
@@ -100,11 +100,11 @@ const PuzzleWrapper = styled.div`
   display: grid;
   width: 100%;
   height: 100%;
-  margin-bottom: 20px;
   grid-template-rows: 60% minmax(40%, 100px);
 
   @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {
     grid-template-rows: unset;
+    padding-bottom: 50px;
   }
 `;
 

--- a/src/components/Tutorial/index.jsx
+++ b/src/components/Tutorial/index.jsx
@@ -15,7 +15,7 @@ function Tutorial() {
     itemId, containerId, prevContainerId,
   }) => {
     dispatch(addChildTree({
-      itemId, containerId, index: 0, prevContainerId, stageId: stage._id,
+      itemId, containerId, challengeIndex: 0, prevContainerId, stageId: stage._id,
     }));
   };
 
@@ -35,6 +35,7 @@ function Tutorial() {
         <Guide>
           <p className="welcome">Mark Up Blocks에 오신 것을 환영합니다!</p>
           <p className="guide-description">아래 태그 블록을 div 안으로 옮겨볼까요?</p>
+          <p className="note">(드래그가 어렵다면 블록을 클릭하고 div 안을 클릭해보세요!)</p>
         </Guide>
       </div>
       <DndInterface
@@ -68,5 +69,10 @@ const Guide = styled.div`
 
   .guide-description {
     font-size: 1.15rem;
+  }
+
+  .note {
+    margin-top: 10px;
+    font-size: 0.8rem;
   }
 `;

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -17,15 +17,15 @@ const challengeSlice = createSlice({
   reducers: {
     addChildTree(state, { payload }) {
       const {
-        prevContainerId, containerId, itemId, index, stageId,
+        challengeIndex, prevContainerId, containerId, itemId, containerIndex, stageId,
       } = payload;
-      const challenge = state.challenges[state.selectedIndex];
+      const challenge = state.challenges[challengeIndex];
       const stage = findBlockTreeById(challenge.elementTree, stageId);
 
       const prevContainer = selectContainer(stage, prevContainerId);
       const container = selectContainer(stage, containerId);
       const blockTree = findBlockTreeById(prevContainer, itemId);
-      const itemIndex = index === -1 ? container.childTrees.length : index;
+      const itemIndex = containerIndex === -1 ? container.childTrees.length : containerIndex;
 
       const isInvalidContainer = !!findBlockTreeById(blockTree, container._id);
       const childTrees = [];
@@ -37,7 +37,7 @@ const challengeSlice = createSlice({
       blockTree.isCorrect = containerId === TYPE.TAG_BLOCK_CONTAINER
         ? false
         : validatePosition({
-          elementTree: challenge.elementTree, container, index, itemId,
+          elementTree: challenge.elementTree, container, index: containerIndex, itemId,
         });
 
       if (container._id === TYPE.TAG_BLOCK_CONTAINER && blockTree.childTrees.length) {

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -27,6 +27,10 @@ const challengeSlice = createSlice({
       const blockTree = findBlockTreeById(prevContainer, itemId);
       const itemIndex = containerIndex === -1 ? container.childTrees.length : containerIndex;
 
+      if (!blockTree) {
+        return;
+      }
+
       const isInvalidContainer = !!findBlockTreeById(blockTree, container._id);
       const childTrees = [];
 

--- a/src/helpers/dataFormatters.js
+++ b/src/helpers/dataFormatters.js
@@ -31,8 +31,25 @@ function formatTagName(isContainer, tagName, text) {
     : `<${tagName}>${text}</${tagName}>`;
 }
 
+function getItemStyles(initialOffset, currentOffset) {
+  if (!initialOffset || !currentOffset) {
+    return {
+      display: "none",
+    };
+  }
+
+  const { x, y } = currentOffset;
+  const transform = `translate(${x}px, ${y}px)`;
+
+  return {
+    transform,
+    WebkitTransform: transform,
+  };
+}
+
 export {
   convertCamelToKebab,
   calcPosition,
   formatTagName,
+  getItemStyles,
 };

--- a/src/theme/global.js
+++ b/src/theme/global.js
@@ -32,16 +32,12 @@ const GlobalStyle = createGlobalStyle`
     animation: 0.3s ease-in-out 0s infinite alternate blink;
   }
 
-  .drop-selected {
+  .selected {
     background-color: ${theme.color.point};
   }
 
   .swing {
     animation: 0.15s ease-in-out 0s infinite alternate swing;
-  }
-
-  .swing:hover {
-    animation: none;
   }
 
   .correct {


### PR DESCRIPTION
closes #53
이슈 중 초기 로딩 관련 사항은 기존 #56 에서 처리되었습니다.


https://user-images.githubusercontent.com/60309558/137636233-a1d11be2-2c8a-4abd-910e-fa77926124b6.mp4


- 모바일 드래그시 isDragging 이펙트 적용
  - 모바일 환경에서 프리뷰 적용을 위해 CustomDragLayer 컴포넌트를 추가하고, useDrag의 기본 프리뷰를 비활성화하였습니다.
  - 상태 관리를 위한 props가 대폭 추가되어, 이후 리팩토링이 필요할 것 같습니다. #58 
- 클릭시 해당 태그 활성화 표시
- 태그블록 클릭 후 드롭위치 클릭으로 드롭 지원
- 모바일에서 완성페이지와 진행페이지 순서 변경
