### PR TITLE
Fix issue50, issue58, issue68 (DndInterface)

### DIFF
--- a/src/components/Challenge/DndInterface/Draggable/index.jsx
+++ b/src/components/Challenge/DndInterface/Draggable/index.jsx
@@ -39,11 +39,10 @@ Draggable.propTypes = {
   content: PropTypes.string.isRequired,
 };
 
-export default Draggable;
-
 const DraggableWrapper = styled.div`
-  margin: 1px 20px;
-  padding: 2px;
+  margin: 0px 20px;
   cursor: pointer;
   border-radius: ${({ theme }) => theme.border.radius.container};
 `;
+
+export default Draggable;

--- a/src/components/Challenge/DndInterface/DropArea/index.jsx
+++ b/src/components/Challenge/DndInterface/DropArea/index.jsx
@@ -5,8 +5,8 @@ import styled from "styled-components";
 
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
-function Droppable({
-  children, _id, index, onDrop, onClick, className, hoveredClassName,
+function DropArea({
+  _id, index, onDrop, onClick, className, needHighlight,
 }) {
   const [{ hovered }, dropRef] = useDrop(() => ({
     accept: Object.values(DRAGGABLE_TYPE),
@@ -28,46 +28,37 @@ function Droppable({
     },
   }), [_id, index]);
 
-  const handleClick = () => {
-    onClick({ containerId: _id, index });
-  };
+  const handleClick = () => onClick({ containerId: _id, index });
 
   return (
-    <DroppableWrapper
-      className={hovered ? hoveredClassName : className}
+    <Area
       ref={dropRef}
+      className={className}
+      hovered={hovered && needHighlight}
       onClick={handleClick}
-    >
-      {children}
-    </DroppableWrapper>
+    />
   );
 }
 
-Droppable.propTypes = {
+DropArea.propTypes = {
   _id: PropTypes.string.isRequired,
-  children: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.arrayOf(PropTypes.element),
-  ]).isRequired,
   index: PropTypes.number,
   onDrop: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
-  hoveredClassName: PropTypes.string,
+  needHighlight: PropTypes.bool,
 };
 
-Droppable.defaultProps = {
+DropArea.defaultProps = {
   index: -1,
   className: "",
-  hoveredClassName: "",
+  needHighlight: false,
 };
 
-export default Droppable;
-
-const DroppableWrapper = styled.div`
-  display: grid;
-  margin: 1px 0;
+const Area = styled.div`
   padding: 3px 0;
-  align-content: space-between;
+  background-color: ${({ hovered, theme }) => (hovered ? theme.color.point : "transparent")};
   cursor: pointer;
 `;
+
+export default DropArea;

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import Draggable from "../Draggable";
-import Droppable from "../Droppable";
+import DropArea from "../DropArea";
 import { tagBlockSchema } from "../TagBlock";
 import Button from "../../../shared/Button";
 
@@ -12,7 +12,7 @@ import { DRAGGABLE_TYPE } from "../../../../constants";
 function DropContainer({
   _id, tagName, childTrees, containerId, selectedTagId,
   onDrop, onClick, onBlockClick,
-  className, droppableClassName, droppableHoveredClassName,
+  className, isDropAreaActive,
 }) {
   function getTextValue(child) {
     return child.isSubChallenge
@@ -34,66 +34,59 @@ function DropContainer({
           value={`<${tagName}>`}
         />
       </div>
+      <DropArea
+        _id={_id}
+        onDrop={onDrop}
+        index={0}
+        onClick={onClick}
+        className={`first-drop-area ${isDropAreaActive ? "drop-guide" : ""}`}
+        needHighlight
+      />
       <>
-        <Droppable
-          key={_id}
-          _id={_id}
-          index={0}
-          onDrop={onDrop}
-          onClick={onClick}
-          className={`droppable ${droppableClassName}`}
-          hoveredClassName={`droppable ${droppableHoveredClassName}`}
-        >
-          <div />
-        </Droppable>
         {childTrees.map((child, index) => (
-          <div key={child._id}>
-            <Draggable
-              _id={child._id}
-              type={child.block.isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
-              containerId={_id}
-              content={getTextValue(child)}
-            >
-              {child.block.isContainer && !child.isSubChallenge
-                ? (
-                  <DropContainer
-                    _id={child._id}
-                    childTrees={child.childTrees}
-                    tagName={child.block.tagName}
-                    onDrop={onDrop}
-                    onClick={onClick}
-                    droppableClassName={droppableClassName}
-                    droppableHoveredClassName={droppableHoveredClassName}
-                    onBlockClick={onBlockClick}
-                    containerId={_id}
-                    selectedTagId={selectedTagId}
+          <Draggable
+            _id={child._id}
+            key={child._id}
+            type={child.block.isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
+            containerId={_id}
+            content={getTextValue(child)}
+          >
+            {child.block.isContainer && !child.isSubChallenge
+              ? (
+                <DropContainer
+                  _id={child._id}
+                  childTrees={child.childTrees}
+                  tagName={child.block.tagName}
+                  onDrop={onDrop}
+                  onBlockClick={onBlockClick}
+                  onClick={onClick}
+                  containerId={_id}
+                  selectedTagId={selectedTagId}
+                  isDropAreaActive={isDropAreaActive}
+                />
+              )
+              : (
+                <div className="tag-text">
+                  <TagButton
+                    className={`${child.isCorrect ? "correct" : "wrong"} ${selectedTagId === child._id ? "selected-tag" : ""}`}
+                    value={getTextValue(child)}
+                    onClick={() => onBlockClick({
+                      _id: child._id,
+                      containerId: _id,
+                      isClicked: true,
+                    })}
                   />
-                )
-                : (
-                  <div className="tag-text">
-                    <TagButton
-                      className={`${child.isCorrect ? "correct" : "wrong"} ${selectedTagId === child._id ? "selected-tag" : ""}`}
-                      value={getTextValue(child)}
-                      onClick={() => onBlockClick({
-                        _id: child._id,
-                        containerId: _id,
-                        isClicked: true,
-                      })}
-                    />
-                  </div>
-                )}
-            </Draggable>
-            <Droppable
+                </div>
+              )}
+            <DropArea
               _id={_id}
-              index={index + 1}
               onDrop={onDrop}
               onClick={onClick}
-              className={`droppable ${droppableClassName}`}
-              hoveredClassName={`droppable ${droppableHoveredClassName}`}
-            >
-              <div />
-            </Droppable>
-          </div>
+              index={index + 1}
+              className={`drop-area ${isDropAreaActive ? "drop-guide" : ""}`}
+              needHighlight
+            />
+          </Draggable>
         ))}
       </>
       <div className="tag-text">
@@ -120,25 +113,24 @@ DropContainer.propTypes = {
     }),
   ).isRequired,
   onDrop: PropTypes.func.isRequired,
-  onClick: PropTypes.func.isRequired,
   onBlockClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
-  droppableClassName: PropTypes.string,
-  droppableHoveredClassName: PropTypes.string,
+  isDropAreaActive: PropTypes.bool.isRequired,
 };
 
 DropContainer.defaultProps = {
   selectedTagId: "",
   className: "",
-  droppableClassName: "",
-  droppableHoveredClassName: "",
 };
 
-export default DropContainer;
-
 const DropContainerWrapper = styled.div`
-  .droppable {
-    margin-left: 20px;
+  .drop-area {
+    margin: 3px 0px;
+  }
+
+  .first-drop-area {
+    margin: 3px 20px;
   }
 
   .parent-tag {
@@ -153,3 +145,5 @@ const DropContainerWrapper = styled.div`
 const TagButton = styled(Button)`
   position: relative;
 `;
+
+export default DropContainer;

--- a/src/components/Challenge/DndInterface/TagBlock/index.jsx
+++ b/src/components/Challenge/DndInterface/TagBlock/index.jsx
@@ -2,52 +2,58 @@ import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import Draggable from "../Draggable";
-import { formatTagName } from "../../../../helpers/dataFormatters";
 
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function TagBlock({
-  _id, isSubChallenge, block, containerId, childTrees, className, onMouseOver, onMouseOut, onClick,
+  _id, content, type, containerId, className, onMouseOver, onMouseOut, onClick,
 }) {
   const ref = useRef(null);
-  const { tagName, isContainer, property } = block;
-  const content = formatTagName(isContainer, tagName, property.text);
-  const handleMouseOver = () => {
-    const position = ref?.current ? ref.current.getBoundingClientRect() : {};
+  const handleSelect = (func) => {
+    const position = ref?.current ? ref.current.getBoundingClientRect() : null;
 
-    onMouseOver({
-      _id, isSubChallenge, block, childTrees, position, containerId,
-    });
-  };
-  const handleClick = () => {
-    const position = ref?.current ? ref.current.getBoundingClientRect() : {};
-
-    onClick({
-      _id, isSubChallenge, block, childTrees, position, containerId,
-    });
+    func({ _id, position, containerId });
   };
 
   return (
     <Draggable
       _id={_id}
-      type={isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
+      type={type}
       containerId={containerId}
       content={content}
     >
       <TagBlockWrapper
         className={className}
-        onMouseOver={handleMouseOver}
+        onMouseOver={() => handleSelect(onMouseOver)}
         onMouseOut={onMouseOut}
         ref={ref}
-        onClick={handleClick}
+        onClick={() => handleSelect(onClick)}
       >
-        <span>{content}</span>
+        {content}
       </TagBlockWrapper>
     </Draggable>
   );
 }
 
-export const tagBlockSchema = {
+TagBlock.propTypes = {
+  _id: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(Object.values(DRAGGABLE_TYPE)).isRequired,
+  containerId: PropTypes.string.isRequired,
+  className: PropTypes.string.isRequired,
+  onMouseOver: PropTypes.func.isRequired,
+  onMouseOut: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
+const TagBlockWrapper = styled.div`
+  padding: 3px 20px;
+  margin: 5px;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => theme.color.point};
+`;
+
+const tagBlockSchema = {
   _id: PropTypes.string.isRequired,
   isSubChallenge: PropTypes.bool.isRequired,
   block: PropTypes.shape({
@@ -63,30 +69,5 @@ export const tagBlockSchema = {
   }).isRequired,
 };
 
-TagBlock.propTypes = {
-  ...tagBlockSchema,
-  containerId: PropTypes.string.isRequired,
-  childTrees: PropTypes.arrayOf(
-    PropTypes.shape(tagBlockSchema),
-  ),
-  className: PropTypes.string,
-  onMouseOver: PropTypes.func,
-  onMouseOut: PropTypes.func,
-  onClick: PropTypes.func,
-};
-
-TagBlock.defaultProps = {
-  childTrees: [],
-  className: "",
-  onMouseOver: () => {},
-  onMouseOut: () => {},
-  onClick: () => {},
-};
-
+export { tagBlockSchema };
 export default TagBlock;
-
-const TagBlockWrapper = styled.div`
-  padding: 3px 20px;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => theme.color.point};
-`;

--- a/src/components/Challenge/DndInterface/TagBlock/index.jsx
+++ b/src/components/Challenge/DndInterface/TagBlock/index.jsx
@@ -16,14 +16,14 @@ function TagBlock({
     const position = ref?.current ? ref.current.getBoundingClientRect() : {};
 
     onMouseOver({
-      _id, isSubChallenge, block, childTrees, position,
+      _id, isSubChallenge, block, childTrees, position, containerId,
     });
   };
   const handleClick = () => {
     const position = ref?.current ? ref.current.getBoundingClientRect() : {};
 
     onClick({
-      _id, isSubChallenge, block, childTrees, position,
+      _id, isSubChallenge, block, childTrees, position, containerId,
     });
   };
 

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -75,7 +75,7 @@ function DndInterface({
       return;
     }
 
-    if (containerId === selected.prevContainerId && containerId === TYPE.TAG_BLOCK_CONTAINER) {
+    if (containerId === selected.containerId && containerId === TYPE.TAG_BLOCK_CONTAINER) {
       return;
     }
 

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -37,6 +37,14 @@ const challengeSlice = createSlice({
         return;
       }
 
+      const prevIndex = prevContainer.childTrees.findIndex((child) => child === blockTree);
+      const isSamePlace = (prevContainer === container)
+        && ((prevIndex && containerIndex) || (prevIndex + 1 === containerIndex));
+
+      if (isSamePlace) {
+        return;
+      }
+
       blockTree.isCorrect = containerId === TYPE.TAG_BLOCK_CONTAINER
         ? false
         : validatePosition({

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -32,7 +32,6 @@ const challengeSlice = createSlice({
       }
 
       const isInvalidContainer = !!findBlockTreeById(blockTree, container._id);
-      const childTrees = [];
 
       if (isInvalidContainer) {
         return;
@@ -44,24 +43,10 @@ const challengeSlice = createSlice({
           elementTree: challenge.elementTree, container, index: containerIndex, itemId,
         });
 
-      if (container._id === TYPE.TAG_BLOCK_CONTAINER && blockTree.childTrees.length) {
-        const tagBlocks = generateBlocks(blockTree, false);
-        const challengeTagBlocks = generateBlocks(stage);
-
-        childTrees.push({ ...blockTree, childTrees: [] });
-        tagBlocks.forEach((child) => {
-          if (challengeTagBlocks.find(({ _id }) => _id === child._id)) {
-            childTrees.push({ ...child, childTrees: [] });
-          }
-        });
-      } else {
-        childTrees.push(blockTree);
-      }
-
       prevContainer.childTrees = prevContainer.childTrees.filter((child) => child._id !== itemId);
       container.childTrees = [
         ...container.childTrees.slice(0, itemIndex),
-        ...childTrees,
+        blockTree,
         ...container.childTrees.slice(itemIndex),
       ];
       stage.isCompleted = compareChildTreeByBlockIds(

--- a/src/helpers/globalSelectors.js
+++ b/src/helpers/globalSelectors.js
@@ -9,6 +9,15 @@ function selectContainer(stage, containerId) {
   return findBlockTreeById(stage.boilerplate, containerId);
 }
 
+function selectBlockTreeById(state, containerId, id) {
+  const { challenges, selectedIndex } = state.challenge;
+  const challenge = challenges[selectedIndex];
+  const stage = findBlockTreeById(challenge.elementTree, challenge.stageId);
+  const container = selectContainer(stage, containerId);
+
+  return findBlockTreeById(container, id);
+}
+
 function selectStageByParams(state, { index, id }) {
   const { challenges, isListLoading, isChallengeLoading } = state.challenge;
   const requestedChallenge = challenges[index];
@@ -70,4 +79,5 @@ function selectStageByParams(state, { index, id }) {
 export {
   selectContainer,
   selectStageByParams,
+  selectBlockTreeById,
 };

--- a/src/hooks/usePick.js
+++ b/src/hooks/usePick.js
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useSelector } from "react-redux";
+
+import { selectBlockTreeById } from "../helpers/globalSelectors";
+
+const initialPicked = {
+  _id: "",
+  containerId: "",
+  enablePreview: false,
+  position: null,
+  isClicked: false,
+};
+
+function usePick() {
+  const [picked, setPicked] = useState(initialPicked);
+  const pickedBlockTree = useSelector(
+    (state) => selectBlockTreeById(state, picked.containerId, picked._id),
+  );
+  const handleReset = () => setPicked(initialPicked);
+  const handleUnpick = () => {
+    if (picked.isClicked) {
+      return;
+    }
+
+    handleReset();
+  };
+
+  const handlePick = (data, pickType) => {
+    const { _id, containerId, position } = data;
+    const updatedPicked = {
+      _id,
+      containerId,
+      position,
+      isClicked: pickType === "click",
+    };
+    const isSecondClick = updatedPicked.isClicked && picked.isClicked && (picked._id === _id);
+
+    if (!_id) {
+      return;
+    }
+
+    if (picked.isClicked && !updatedPicked.isClicked) {
+      return;
+    }
+
+    if (isSecondClick) {
+      handleReset();
+      return;
+    }
+
+    setPicked(updatedPicked);
+  };
+
+  return {
+    picked: pickedBlockTree
+      ? { ...picked, ...pickedBlockTree, enablePreview: !!picked.position }
+      : picked,
+    onPick: handlePick,
+    onUnpick: handleUnpick,
+    onReset: handleReset,
+  };
+}
+
+export { usePick };


### PR DESCRIPTION
closes #50 
첫번째 위치에 drop시 index 반영 오류
- 같은 인덱스를 공유하는 drop guideline이 2종류여서 발생한 문제입니다.
- 태그 블록 기준으로 자신의 바로 위쪽과 바로 아래쪽 드롭 가이드라인에 드롭시 무시하도록 처리하였습니다.            
- challenge addChildTree에 isSamePlace 플래그를 추가하였습니다.

closes #58
  - DndInterface의 기존 선택 관련 로직을 usePick hook으로 이동하였습니다.
  - 이슈였던 선택 상태 관련 props(hoveredClassName 등)을 압축 후 플래그 변수로 처리하였습니다.
  - children이 필요없는 Droppable은 DropArea로 이름 변경 후, children을 받지 않고 렌더링하도록 변경하였습니다.
  - TagBlock에서 직접 넘겨주던 blockTree 관련 데이터를 DndInterface에서 렌더링 시 처리하도록 수정하여, TagBlock의 props가 간소화되었습니다.

closes #68 
- 태그 블록을 확인하려고 블록을 눌렀을 때 container 드롭으로 인식해 위치가 변경되는 현상
  - TagBlockContainer에서 TagBlockContainer로 드롭시 무시하도록 처리하였습니다.
 
- 클릭 드롭시 중간에 정보 유실되어, 정답을 맞추더라도 처리되지 않는 현상
  - 기존 challenge reducer 47 ~ 60번 라인 때문에 발생한 오류입니다.
  - 기존에는 TagBlockContainer의 자식인 경우 childTrees를 비우고 추가되도록 작업되었으나, 실제 childTrees는 이후 display와 preview에서 렌더링시 isSubChallenge 변수로 처리되기 때문에 현재는 필요없는 부분입니다. 해당 부분 삭제 이후 정상 작동합니다.