### PR TITLE
Fix: itemIndex condition error

### DIFF
--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -25,7 +25,7 @@ const challengeSlice = createSlice({
       const prevContainer = selectContainer(stage, prevContainerId);
       const container = selectContainer(stage, containerId);
       const blockTree = findBlockTreeById(prevContainer, itemId);
-      const itemIndex = containerIndex === -1 ? container.childTrees.length : containerIndex;
+      let itemIndex = containerIndex === -1 ? container.childTrees.length : containerIndex;
 
       if (!blockTree) {
         return;
@@ -37,12 +37,16 @@ const challengeSlice = createSlice({
         return;
       }
 
-      const prevIndex = prevContainer.childTrees.findIndex((child) => child === blockTree);
-      const isSamePlace = (prevContainer === container)
-        && ((prevIndex && containerIndex) || (prevIndex + 1 === containerIndex));
+      if (prevContainer === container) {
+        const prevIndex = prevContainer.childTrees.findIndex((child) => child === blockTree);
 
-      if (isSamePlace) {
-        return;
+        if ((prevIndex === itemIndex) || (prevIndex + 1 === itemIndex)) {
+          return;
+        }
+
+        if (itemIndex > prevIndex) {
+          itemIndex -= 1;
+        }
       }
 
       blockTree.isCorrect = containerId === TYPE.TAG_BLOCK_CONTAINER


### PR DESCRIPTION
#50 이슈 관련, #69 PR에서 빠진 조건을 추가하였습니다.

같은 컨테이너에서 기존에 앞쪽에 있었던 요소(ex index 1)가 뒤쪽(ex index 3)으로 이동하는 경우, 기존 자신의 개수까지 반영된 인덱스가 적용되고 있었습니다.
`itemIndex > prevIndex` 조건문을 추가하여, 같은 컨테이너일 때 기존보다 인덱스가 뒤로 가는 경우 1(자기 자신)을 빼고 새 인덱스를 계산하도록 수정하였습니다.