### PR TITLE
Fix: HTMLViewer root challenge movable error, mark completed challenge

### DIFF
--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -10,7 +10,7 @@ import { tagBlockSchema } from "../TagBlock";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropContainer({
-  _id, tagName, childTrees, containerId, selectedTagId,
+  _id, tagName, childTrees, containerId, selectedTagId, isSubChallenge,
   onDrop, onClick, onBlockClick,
   className, isDropAreaActive,
 }) {
@@ -22,14 +22,14 @@ function DropContainer({
     <DropContainerWrapper className={className}>
       <div
         className="tag-text"
-        onClick={handleTagClick}
-        onKeyPress={handleTagClick}
+        onClick={isSubChallenge ? () => {} : handleTagClick}
+        onKeyPress={isSubChallenge ? () => {} : handleTagClick}
         role="button"
         tabIndex="0"
       >
         <HighlightedTag
           isContainer
-          isSubChallenge={false}
+          isSubChallenge={isSubChallenge}
           tagName={tagName}
           type="open"
         />
@@ -62,6 +62,7 @@ function DropContainer({
                   containerId={_id}
                   selectedTagId={selectedTagId}
                   isDropAreaActive={isDropAreaActive}
+                  isSubChallenge={false}
                 />
               )
               : (
@@ -97,14 +98,14 @@ function DropContainer({
       </>
       <div
         className="tag-text"
-        onClick={handleTagClick}
-        onKeyPress={handleTagClick}
+        onClick={isSubChallenge ? () => {} : handleTagClick}
+        onKeyPress={isSubChallenge ? () => {} : handleTagClick}
         role="button"
         tabIndex="0"
       >
         <HighlightedTag
           isContainer
-          isSubChallenge={false}
+          isSubChallenge={isSubChallenge}
           tagName={tagName}
           type="close"
         />
@@ -124,6 +125,7 @@ DropContainer.propTypes = {
       isCorrect: PropTypes.bool,
     }),
   ).isRequired,
+  isSubChallenge: PropTypes.bool.isRequired,
   onDrop: PropTypes.func.isRequired,
   onBlockClick: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
+++ b/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
@@ -4,6 +4,26 @@ import PropTypes from "prop-types";
 function HighlightedTag({
   tagName, text, isSubChallenge, isContainer, type,
 }) {
+  if (isSubChallenge && type === "open") {
+    return (
+      <>
+        <span key="self-open">{"<"}</span>
+        <span key="self-tagName" className="challenge-tag">{tagName}</span>
+        <span key="self-close">{">"}</span>
+      </>
+    );
+  }
+
+  if (isSubChallenge && type === "close") {
+    return (
+      <>
+        <span key="self-open">{"</"}</span>
+        <span key="self-tagName" className="challenge-tag">{tagName}</span>
+        <span key="self-close">{">"}</span>
+      </>
+    );
+  }
+
   if (isContainer && type === "open") {
     return (
       <>
@@ -25,11 +45,13 @@ function HighlightedTag({
   }
 
   if (isSubChallenge && type === "self-closing") {
-    <>
-      <span key="self-open">{"<"}</span>
-      <span key="self-tagName" className="challenge-tag">{tagName}</span>
-      <span key="self-close">{" />"}</span>
-    </>;
+    return (
+      <>
+        <span key="self-open">{"<"}</span>
+        <span key="self-tagName" className="challenge-tag">{tagName}</span>
+        <span key="self-close">{" />"}</span>
+      </>
+    );
   }
 
   if (isSubChallenge) {

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -86,6 +86,7 @@ function DndInterface({
           containerId={boilerplate._id}
           childTrees={boilerplate.childTrees}
           tagName={boilerplate.block.tagName}
+          isSubChallenge
           onDrop={handleDrop}
           onClick={handleClickDrop}
           onBlockClick={(data) => onPick(data, "click")}

--- a/src/features/challenge.js
+++ b/src/features/challenge.js
@@ -1,7 +1,9 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { fetchChallengeList, fetchChallenge } from "./challengeThunks";
 import { generateBlocks } from "../helpers/tagBlockGenerators";
-import { findBlockTreeById, compareChildTreeByBlockIds, validatePosition } from "../helpers/blockTreeHandlers";
+import {
+  findBlockTreeById, compareChildTreeByBlockIds, validatePosition, findNextUncompletedChallenge,
+} from "../helpers/blockTreeHandlers";
 import { selectContainer } from "../helpers/globalSelectors";
 import tutorialData from "../components/Tutorial/tutorialData";
 import { TYPE } from "../constants";
@@ -64,6 +66,14 @@ const challengeSlice = createSlice({
       stage.isCompleted = compareChildTreeByBlockIds(
         stage, stage.boilerplate,
       );
+
+      if (stage.isCompleted) {
+        const nextStage = findNextUncompletedChallenge(challenge.elementTree, stageId);
+
+        if (!nextStage) {
+          challenge.isCompleted = true;
+        }
+      }
     },
     resetStage(state, { payload }) {
       const stageId = payload;


### PR DESCRIPTION
아래 오류를 수정하였습니다.
- HTMLViewer의 각 stage root 태그를 클릭시 드롭 가능한 이슈
  - stage root 태그는 이동 불가능해야 하나, HighlightedTag로 대체하면서 onClick 핸들러가 일괄 적용되어 발생한 오류입니다.
  - isSubChallenge 변수를 prop으로 받도록 수정하고, 해당 변수가 true인 경우 빈 핸들러를 넘겨주도록 수정하였습니다.
- 오른쪽 상단의 challenge menu에서 완료 챌린지가 표시되지 않던 이슈
 - challenge.isCompleted 속성이 적용되지 않고 있어서 발생한 이슈입니다.
 - 변동이 발생하는 부분인 challenge reducer의 addChildTree에서 완료여부 함께 처리하도록 수정하였습니다.