### PR TITLE
Fix: issue42  (ElementBlock)

### DIFF
--- a/src/components/Challenge/Display/ElementBlock/index.jsx
+++ b/src/components/Challenge/Display/ElementBlock/index.jsx
@@ -2,7 +2,7 @@ import React, { createElement } from "react";
 import PropTypes from "prop-types";
 
 function ElementBlock({ _id, block, childTrees }) {
-  const { tagName, isContainer } = block;
+  const { tagName } = block;
 
   function preventDefault(event) {
     event.preventDefault();
@@ -22,7 +22,7 @@ function ElementBlock({ _id, block, childTrees }) {
     property.onSubmit = preventDefault;
   }
 
-  if (isContainer) {
+  if (childTrees.length > 0) {
     return createElement(
       tagName,
       property,

--- a/src/components/Challenge/DndInterface/Preview/index.jsx
+++ b/src/components/Challenge/DndInterface/Preview/index.jsx
@@ -11,9 +11,9 @@ function Preview({
   const styles = Object.entries(block?.property?.style || {})
     .map(([key, value]) => [convertCamelToKebab(key), value])
     .sort((a, b) => b[0] > a[0]);
-  const previewChildTrees = block.isContainer
+  const previewChildTrees = !isSubChallenge && block.isContainer && childTrees.length
     ? [{ _id: "virtualChild", block: { tagName: "span", property: { text: "child" }, isContainer: false } }]
-    : [];
+    : childTrees;
   const { top, left } = calcPosition(position, { width: 300, height: 150 });
 
   return (
@@ -22,7 +22,7 @@ function Preview({
         <ElementBlock
           _id="preview"
           block={block}
-          childTrees={isSubChallenge ? childTrees : previewChildTrees}
+          childTrees={previewChildTrees}
         />
       </div>
       <div className="preview-style">


### PR DESCRIPTION
closes #42 
svg의 자식으로만 사용되는 path 태그를 단일 렌더링시 발생하는 오류였습니다.
- 기존에 db에 저장된 정보에서 TagBlock의 isContainer 속성 값은 단순히 자식을 가지고 있는지 여부를 가리켰습니다.
- 다만 단순 자식 여부는 BlockTree의 childTrees 배열 length로도 판단할 수 있으므로, isContainer 속성이 가리키는 값을 '자식을 개별 태그로 취급해야하는가'로 의미를 변경하고, 자식을 별도의 태그로 렌더링할 필요 없는 svg 태그의 경우 isContainer 값을 false로 주었습니다.
- 변경 후 클라이언트에서 태그블록으로 렌더링시, svg는 자식태그를 포함해 렌더링되며, path 태그는 별도의 태그로 취급되지 않습니다.
- helper 함수 generateBlocks에서는 이미 isContainer가 true인 경우에만 자식을 개별 태그 취급하고 있어, ElementBlock으로 렌더링하는 부분만 수정하였습니다.