### PR TITLE
Fix: issue54 (tag ref link)

### DIFF
--- a/src/components/Challenge/Display/ElementBlock/index.jsx
+++ b/src/components/Challenge/Display/ElementBlock/index.jsx
@@ -37,10 +37,6 @@ function ElementBlock({ _id, block, childTrees }) {
     );
   }
 
-  if (["input", "textarea"].includes(tagName)) {
-    property.readOnly = true;
-  }
-
   if (block.property.text) {
     return createElement(
       tagName,

--- a/src/components/Challenge/DndInterface/Preview/index.jsx
+++ b/src/components/Challenge/DndInterface/Preview/index.jsx
@@ -15,6 +15,9 @@ function Preview({
     ? [{ _id: "virtualChild", block: { tagName: "span", property: { text: "child" }, isContainer: false } }]
     : childTrees;
   const { top, left } = calcPosition(position, { width: 300, height: 150 });
+  const refURL = block.tagName === "svg"
+    ? `${process.env.REACT_APP_REF_URI_SVG}/${block.tagName}`
+    : `${process.env.REACT_APP_REF_URI}/${block.tagName}`;
 
   return (
     <PreviewWrapper className={className} top={top} left={left} onClick={onClick}>
@@ -26,6 +29,7 @@ function Preview({
         />
       </div>
       <div className="preview-style">
+        <a href={refURL}>{block.tagName}</a>
         {styles.map(([key, value]) => (
           <p key={key}>{`${key}: ${value};`}</p>
         ))}
@@ -82,6 +86,7 @@ const PreviewWrapper = styled.div`
   justify-content: start;
 
   .preview-element {
+    position: relative;
     display: flex;
     margin: auto;
     padding: 10px;


### PR DESCRIPTION
closes #54 
![issue54](https://user-images.githubusercontent.com/60309558/139068913-053ffbf7-7305-4394-a9b9-c25d47718397.gif)

tag 관련 정보 링크를 추가하였습니다.
  - 이와 관련하여 아래 환경변수 2종을 추가하였습니다. 현재는 mdn으로 연결하고 있으나, 이후 변동 가능성이 있다고 판단해 환경변수로 처리하였습니다.
  - REACT_APP_REF_URI
    - https://developer.mozilla.org/ko/docs/Web/HTML/Element
  - REACT_APP_REF_URI_SVG (일반 element tag가 아니기 때문에 별도로 분리)
    - https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg
 
퀴즈 데이터가 늘어나면서 유저와 상호작용 범위를 늘리기 위해 input 태그 입력창을 활성화하였습니다.
