### PR TITLE
Fix: issue75 (refactor DndInterface)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -117,11 +117,11 @@ function App() {
   );
 }
 
-export default App;
-
 const AppWrapper = styled.div`
   display: grid;
   width: 100%;
   height: 100%;
   grid-template-rows: 50px auto;
 `;
+
+export default App;

--- a/src/components/Challenge/Display/index.jsx
+++ b/src/components/Challenge/Display/index.jsx
@@ -1,14 +1,17 @@
 import React from "react";
-import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 import ElementBlock from "./ElementBlock";
+
+import { selectStage } from "../../../helpers/globalSelectors";
 import { TYPE } from "../../../constants";
 
-function Display({ boilerplate, elementTree }) {
+function Display() {
+  const stage = useSelector(selectStage);
   const pages = [
-    { ...boilerplate, key: TYPE.BOILERPLATE },
-    { ...elementTree, key: TYPE.ELEMENT_TREE },
+    { ...stage.boilerplate, key: TYPE.BOILERPLATE },
+    { ...stage.elementTree, key: TYPE.ELEMENT_TREE },
   ];
 
   return (
@@ -27,13 +30,6 @@ function Display({ boilerplate, elementTree }) {
     </Container>
   );
 }
-
-Display.propTypes = {
-  boilerplate: PropTypes.shape(ElementBlock.propTypes).isRequired,
-  elementTree: PropTypes.shape(ElementBlock.propTypes).isRequired,
-};
-
-export default Display;
 
 const Container = styled.div`
   display: grid;
@@ -62,3 +58,5 @@ const PageWrapper = styled.div`
     order: ${({ index }) => -index};
   }
 `;
+
+export default Display;

--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -27,7 +27,7 @@ function CustomDragLayer() {
 
   return (
     <Layer>
-      <span style={getItemStyles(initialOffset, currentOffset)} className="dragging-content">
+      <span style={getItemStyles(initialOffset, currentOffset)}>
         {blockTree && (
         <HighlightedTag
           tagType={blockTree.tagType}
@@ -49,10 +49,6 @@ const Layer = styled.div`
   top: 0;
   width: 100%;
   height: 100%;
-
-  .dragging-content {
-    height: 25px;
-  }
 `;
 
 export default CustomDragLayer;

--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -7,18 +7,6 @@ import HighlightedTag from "../HighlightedTag";
 import { selectBlockTreeById } from "../../../../helpers/globalSelectors";
 import { getItemStyles } from "../../../../helpers/dataFormatters";
 
-function getTagType(blockTree) {
-  if (blockTree.isSubChallenge) {
-    return "stage";
-  }
-
-  if (blockTree.block.isContainer) {
-    return "container";
-  }
-
-  return "tag";
-}
-
 function CustomDragLayer() {
   const {
     isDragging, item, initialOffset, currentOffset,
@@ -32,7 +20,6 @@ function CustomDragLayer() {
   const blockTree = useSelector(
     (state) => selectBlockTreeById(state, item?.prevContainerId, item?.itemId),
   );
-  const tagType = blockTree ? getTagType(blockTree) : "tag";
 
   if (!isDragging) {
     return null;
@@ -43,9 +30,9 @@ function CustomDragLayer() {
       <span style={getItemStyles(initialOffset, currentOffset)} className="dragging-content">
         {blockTree && (
         <HighlightedTag
-          tagType={tagType}
+          tagType={blockTree.tagType}
           tagName={blockTree.block.tagName}
-          text={tagType === "stage" ? blockTree.title : blockTree.block.property.text}
+          text={blockTree.tagType === "stage" ? blockTree.title : blockTree.block.property.text}
         />
         )}
       </span>

--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -34,6 +34,7 @@ function CustomDragLayer() {
           text={blockTree.block.property.text}
           isSubChallenge={blockTree.isSubChallenge}
           isContainer={blockTree.block.isContainer}
+          title={blockTree.title}
         />
         )}
       </span>

--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -7,6 +7,18 @@ import HighlightedTag from "../HighlightedTag";
 import { selectBlockTreeById } from "../../../../helpers/globalSelectors";
 import { getItemStyles } from "../../../../helpers/dataFormatters";
 
+function getTagType(blockTree) {
+  if (blockTree.isSubChallenge) {
+    return "stage";
+  }
+
+  if (blockTree.block.isContainer) {
+    return "container";
+  }
+
+  return "tag";
+}
+
 function CustomDragLayer() {
   const {
     isDragging, item, initialOffset, currentOffset,
@@ -20,6 +32,7 @@ function CustomDragLayer() {
   const blockTree = useSelector(
     (state) => selectBlockTreeById(state, item?.prevContainerId, item?.itemId),
   );
+  const tagType = blockTree ? getTagType(blockTree) : "tag";
 
   if (!isDragging) {
     return null;
@@ -30,11 +43,9 @@ function CustomDragLayer() {
       <span style={getItemStyles(initialOffset, currentOffset)} className="dragging-content">
         {blockTree && (
         <HighlightedTag
+          tagType={tagType}
           tagName={blockTree.block.tagName}
-          text={blockTree.block.property.text}
-          isSubChallenge={blockTree.isSubChallenge}
-          isContainer={blockTree.block.isContainer}
-          title={blockTree.title}
+          text={tagType === "stage" ? blockTree.title : blockTree.block.property.text}
         />
         )}
       </span>

--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -40,8 +40,6 @@ function CustomDragLayer() {
   );
 }
 
-export default CustomDragLayer;
-
 const Layer = styled.div`
   position: fixed;
   display: flex;
@@ -56,3 +54,5 @@ const Layer = styled.div`
     height: 25px;
   }
 `;
+
+export default CustomDragLayer;

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -10,7 +10,7 @@ import { tagBlockSchema } from "../TagBlock";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropContainer({
-  _id, tagName, childTrees, containerId, selectedTagId, isSubChallenge, title,
+  _id, tagName, childTrees, containerId, selectedTagId, isSubChallenge,
   onDrop, onClick, onBlockClick,
   className, isDropAreaActive,
 }) {
@@ -28,11 +28,8 @@ function DropContainer({
         tabIndex="0"
       >
         <HighlightedTag
-          isContainer
-          isSubChallenge={isSubChallenge}
+          tagType="container-open"
           tagName={tagName}
-          type="open"
-          title={title}
         />
       </div>
       <DropArea
@@ -79,11 +76,9 @@ function DropContainer({
                   tabIndex="0"
                 >
                   <HighlightedTag
-                    isContainer={false}
-                    isSubChallenge={child.isSubChallenge}
+                    tagType={child.isSubChallenge ? "stage" : "tag"}
                     tagName={child.block.tagName}
-                    text={child.block.property.text}
-                    title={child.title}
+                    text={child.isSubChallenge ? child.title : child.block.property.text}
                   />
                 </div>
               )}
@@ -106,11 +101,8 @@ function DropContainer({
         tabIndex="0"
       >
         <HighlightedTag
-          isContainer
-          isSubChallenge={isSubChallenge}
+          tagType="container-close"
           tagName={tagName}
-          type="close"
-          title={title}
         />
       </div>
     </DropContainerWrapper>
@@ -134,7 +126,6 @@ DropContainer.propTypes = {
   onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   isDropAreaActive: PropTypes.bool.isRequired,
-  title: PropTypes.string.isRequired,
 };
 
 DropContainer.defaultProps = {

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -10,7 +10,7 @@ import { tagBlockSchema } from "../TagBlock";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropContainer({
-  _id, tagName, childTrees, containerId, selectedTagId, isSubChallenge,
+  _id, tagName, childTrees, containerId, selectedTagId, isSubChallenge, title,
   onDrop, onClick, onBlockClick,
   className, isDropAreaActive,
 }) {
@@ -32,6 +32,7 @@ function DropContainer({
           isSubChallenge={isSubChallenge}
           tagName={tagName}
           type="open"
+          title={title}
         />
       </div>
       <DropArea
@@ -82,6 +83,7 @@ function DropContainer({
                     isSubChallenge={child.isSubChallenge}
                     tagName={child.block.tagName}
                     text={child.block.property.text}
+                    title={child.title}
                   />
                 </div>
               )}
@@ -108,6 +110,7 @@ function DropContainer({
           isSubChallenge={isSubChallenge}
           tagName={tagName}
           type="close"
+          title={title}
         />
       </div>
     </DropContainerWrapper>
@@ -131,6 +134,7 @@ DropContainer.propTypes = {
   onClick: PropTypes.func.isRequired,
   className: PropTypes.string,
   isDropAreaActive: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 DropContainer.defaultProps = {

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -19,25 +19,19 @@ function DropContainer({
   };
 
   return (
-    <DropContainerWrapper className={className}>
-      <div
-        className="tag-text"
-        onClick={isSubChallenge ? () => {} : handleTagClick}
-        onKeyPress={isSubChallenge ? () => {} : handleTagClick}
-        role="button"
-        tabIndex="0"
-      >
+    <div className={className}>
+      <TextTag onClick={isSubChallenge ? () => {} : handleTagClick}>
         <HighlightedTag
           tagType="container-open"
           tagName={tagName}
         />
-      </div>
-      <DropArea
+      </TextTag>
+      <FirstDropArea
         _id={_id}
         onDrop={onDrop}
         index={0}
         onClick={onClick}
-        className={`first-drop-area ${isDropAreaActive ? "drop-guide" : ""}`}
+        className={isDropAreaActive ? "drop-guide" : ""}
         needHighlight
       />
       <>
@@ -64,48 +58,39 @@ function DropContainer({
                 />
               )
               : (
-                <div
-                  className={`tag-text ${selectedTagId === child._id ? "selected-tag" : ""}`}
+                <TextTag
                   onClick={() => onBlockClick({
                     _id: child._id,
                     containerId: _id,
                     isClicked: true,
                   })}
-                  onKeyPress={handleTagClick}
-                  role="button"
-                  tabIndex="0"
                 >
                   <HighlightedTag
                     tagType={child.isSubChallenge ? "stage" : "tag"}
+                    className={selectedTagId === child._id ? "selected-tag" : ""}
                     tagName={child.block.tagName}
                     text={child.isSubChallenge ? child.title : child.block.property.text}
                   />
-                </div>
+                </TextTag>
               )}
-            <DropArea
+            <BackwardDropArea
               _id={_id}
               onDrop={onDrop}
               onClick={onClick}
               index={index + 1}
-              className={`drop-area ${isDropAreaActive ? "drop-guide" : ""}`}
+              className={isDropAreaActive ? "drop-guide" : ""}
               needHighlight
             />
           </Draggable>
         ))}
       </>
-      <div
-        className="tag-text"
-        onClick={isSubChallenge ? () => {} : handleTagClick}
-        onKeyPress={isSubChallenge ? () => {} : handleTagClick}
-        role="button"
-        tabIndex="0"
-      >
+      <TextTag onClick={isSubChallenge ? () => {} : handleTagClick}>
         <HighlightedTag
           tagType="container-close"
           tagName={tagName}
         />
-      </div>
-    </DropContainerWrapper>
+      </TextTag>
+    </div>
   );
 }
 
@@ -133,14 +118,26 @@ DropContainer.defaultProps = {
   className: "",
 };
 
-const DropContainerWrapper = styled.div`
-  .drop-area {
-    margin: 4px 0px;
-  }
+const FirstDropArea = styled(DropArea)`
+  margin: 4px 20px;
+`;
 
-  .first-drop-area {
-    margin: 4px 20px;
+const BackwardDropArea = styled(DropArea)`
+  margin: 4px 0;
+`;
+
+const TextTag = styled.div`
+  :before {
+    position: absolute;
+    right: 100%;
+    margin-right: -20px;
+    text-align: right;
+    font-size: 0.8rem;
+    counter-increment: line;
+    content: counter(line);
+    color: ${({ theme }) => theme.color.inactive};
   }
 `;
 
+export { TextTag };
 export default DropContainer;

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -1,29 +1,32 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import Draggable from "../Draggable";
 import DropArea from "../DropArea";
 import HighlightedTag from "../HighlightedTag";
-import { tagBlockSchema } from "../TagBlock";
 
+import { selectBlockTreeById } from "../../../../helpers/globalSelectors";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropContainer({
-  _id, tagName, childTrees, containerId, selectedTagId, isSubChallenge,
+  _id, containerId, selectedTagId,
   onDrop, onClick, onBlockClick,
-  className, isDropAreaActive,
+  isDropAreaActive,
 }) {
+  const blockTree = useSelector((state) => selectBlockTreeById(state, containerId, _id));
+  const { block, childTrees } = blockTree;
   const handleTagClick = () => {
     onBlockClick({ _id, containerId, isClicked: true });
   };
 
   return (
-    <div className={className}>
-      <TextTag onClick={isSubChallenge ? () => {} : handleTagClick}>
+    <div>
+      <TextTag onClick={containerId ? () => {} : handleTagClick}>
         <HighlightedTag
           tagType="container-open"
-          tagName={tagName}
+          tagName={block.tagName}
         />
       </TextTag>
       <FirstDropArea
@@ -46,15 +49,12 @@ function DropContainer({
               ? (
                 <DropContainer
                   _id={child._id}
-                  childTrees={child.childTrees}
-                  tagName={child.block.tagName}
-                  onDrop={onDrop}
-                  onBlockClick={onBlockClick}
-                  onClick={onClick}
                   containerId={_id}
                   selectedTagId={selectedTagId}
+                  onDrop={onDrop}
+                  onClick={onClick}
+                  onBlockClick={onBlockClick}
                   isDropAreaActive={isDropAreaActive}
-                  isSubChallenge={false}
                 />
               )
               : (
@@ -84,10 +84,10 @@ function DropContainer({
           </Draggable>
         ))}
       </>
-      <TextTag onClick={isSubChallenge ? () => {} : handleTagClick}>
+      <TextTag onClick={containerId ? () => {} : handleTagClick}>
         <HighlightedTag
           tagType="container-close"
-          tagName={tagName}
+          tagName={block.tagName}
         />
       </TextTag>
     </div>
@@ -97,25 +97,15 @@ function DropContainer({
 DropContainer.propTypes = {
   _id: PropTypes.string.isRequired,
   containerId: PropTypes.string.isRequired,
-  tagName: PropTypes.string.isRequired,
   selectedTagId: PropTypes.string,
-  childTrees: PropTypes.arrayOf(
-    PropTypes.shape({
-      ...tagBlockSchema,
-      isCorrect: PropTypes.bool,
-    }),
-  ).isRequired,
-  isSubChallenge: PropTypes.bool.isRequired,
-  onDrop: PropTypes.func.isRequired,
   onBlockClick: PropTypes.func.isRequired,
+  onDrop: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
-  className: PropTypes.string,
   isDropAreaActive: PropTypes.bool.isRequired,
 };
 
 DropContainer.defaultProps = {
   selectedTagId: "",
-  className: "",
 };
 
 const FirstDropArea = styled(DropArea)`

--- a/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
+++ b/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 function HighlightedTag({
-  tagName, text, isSubChallenge, isContainer, type,
+  tagName, text, isSubChallenge, isContainer, type, title,
 }) {
   if (isSubChallenge && type === "open") {
     return (
@@ -60,7 +60,7 @@ function HighlightedTag({
         <span key="open-open">{"<"}</span>
         <span key="open-tagName" className="challenge-tag">{tagName}</span>
         <span key="open-close">{">"}</span>
-        <span key="text">stage</span>
+        <span key="text">{title}</span>
         <span key="close-open">{"</"}</span>
         <span key="close-tagName" className="challenge-tag">{tagName}</span>
         <span key="close-close">{">"}</span>
@@ -110,6 +110,7 @@ HighlightedTag.propTypes = {
   isSubChallenge: PropTypes.bool.isRequired,
   isContainer: PropTypes.bool.isRequired,
   type: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };
 
 HighlightedTag.defaultProps = {

--- a/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
+++ b/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
@@ -2,30 +2,32 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-function HighlightedTag({ tagType, tagName, text }) {
+function HighlightedTag({
+  tagType, tagName, text, className,
+}) {
   if (tagType === "container-open" || tagType === "container-close") {
     return (
       <Tag>
-        <span>{tagType === "container-open" ? "<" : "</"}</span>
+        <span className={className}>{tagType === "container-open" ? "<" : "</"}</span>
         <span className="container">{tagName}</span>
-        <span>{">"}</span>
+        <span className={className}>{">"}</span>
       </Tag>
     );
   }
 
   return (
     <Tag>
-      <span>{"<"}</span>
+      <span className={className}>{"<"}</span>
       <span className={tagType}>{tagName}</span>
       {(tagType === "tag" && !text)
-        ? <span>{" />"}</span>
+        ? <span className={className}>{" />"}</span>
         : (
           <>
-            <span>{">"}</span>
+            <span className={className}>{">"}</span>
             <span>{text}</span>
-            <span>{"</"}</span>
+            <span className={className}>{"</"}</span>
             <span className={tagType}>{tagName}</span>
-            <span>{">"}</span>
+            <span className={className}>{">"}</span>
           </>
         )}
     </Tag>
@@ -42,10 +44,12 @@ HighlightedTag.propTypes = {
   ]).isRequired,
   tagName: PropTypes.string.isRequired,
   text: PropTypes.string,
+  className: PropTypes.string,
 };
 
 HighlightedTag.defaultProps = {
   text: "",
+  className: "",
 };
 
 const Tag = styled.span`

--- a/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
+++ b/src/components/Challenge/DndInterface/HighlightedTag/index.jsx
@@ -1,121 +1,65 @@
 import React from "react";
 import PropTypes from "prop-types";
+import styled from "styled-components";
 
-function HighlightedTag({
-  tagName, text, isSubChallenge, isContainer, type, title,
-}) {
-  if (isSubChallenge && type === "open") {
+function HighlightedTag({ tagType, tagName, text }) {
+  if (tagType === "container-open" || tagType === "container-close") {
     return (
-      <>
-        <span key="self-open">{"<"}</span>
-        <span key="self-tagName" className="challenge-tag">{tagName}</span>
-        <span key="self-close">{">"}</span>
-      </>
-    );
-  }
-
-  if (isSubChallenge && type === "close") {
-    return (
-      <>
-        <span key="self-open">{"</"}</span>
-        <span key="self-tagName" className="challenge-tag">{tagName}</span>
-        <span key="self-close">{">"}</span>
-      </>
-    );
-  }
-
-  if (isContainer && type === "open") {
-    return (
-      <>
-        <span key="open-open">{"<"}</span>
-        <span key="open-tagName" className="parent-tag">{tagName}</span>
-        <span key="open-close">{">"}</span>
-      </>
-    );
-  }
-
-  if (isContainer && type === "close") {
-    return (
-      <>
-        <span key="close-open">{"</"}</span>
-        <span key="close-tagName" className="parent-tag">{tagName}</span>
-        <span key="close-close">{">"}</span>
-      </>
-    );
-  }
-
-  if (isSubChallenge && type === "self-closing") {
-    return (
-      <>
-        <span key="self-open">{"<"}</span>
-        <span key="self-tagName" className="challenge-tag">{tagName}</span>
-        <span key="self-close">{" />"}</span>
-      </>
-    );
-  }
-
-  if (isSubChallenge) {
-    return (
-      <>
-        <span key="open-open">{"<"}</span>
-        <span key="open-tagName" className="challenge-tag">{tagName}</span>
-        <span key="open-close">{">"}</span>
-        <span key="text">{title}</span>
-        <span key="close-open">{"</"}</span>
-        <span key="close-tagName" className="challenge-tag">{tagName}</span>
-        <span key="close-close">{">"}</span>
-      </>
-    );
-  }
-
-  if (isContainer) {
-    return (
-      <>
-        <span key="open-open">{"<"}</span>
-        <span key="open-tagName" className="parent-tag">{tagName}</span>
-        <span key="open-close">{">"}</span>
-        <span key="close-open">{"</"}</span>
-        <span key="close-tagName" className="parent-tag">{tagName}</span>
-        <span key="close-close">{">"}</span>
-      </>
-    );
-  }
-
-  if (text) {
-    return (
-      <>
-        <span key="open-open">{"<"}</span>
-        <span key="open-tagName" className="child-tag">{tagName}</span>
-        <span key="open-close">{">"}</span>
-        <span key="text">{text}</span>
-        <span key="close-open">{"</"}</span>
-        <span key="close-tagName" className="child-tag">{tagName}</span>
-        <span key="close-close">{">"}</span>
-      </>
+      <Tag>
+        <span>{tagType === "container-open" ? "<" : "</"}</span>
+        <span className="container">{tagName}</span>
+        <span>{">"}</span>
+      </Tag>
     );
   }
 
   return (
-    <>
-      <span key="self-open">{"<"}</span>
-      <span key="self-tagName" className="child-tag">{tagName}</span>
-      <span key="self-close">{" />"}</span>
-    </>
+    <Tag>
+      <span>{"<"}</span>
+      <span className={tagType}>{tagName}</span>
+      {(tagType === "tag" && !text)
+        ? <span>{" />"}</span>
+        : (
+          <>
+            <span>{">"}</span>
+            <span>{text}</span>
+            <span>{"</"}</span>
+            <span className={tagType}>{tagName}</span>
+            <span>{">"}</span>
+          </>
+        )}
+    </Tag>
   );
 }
 
 HighlightedTag.propTypes = {
+  tagType: PropTypes.oneOf([
+    "stage",
+    "container",
+    "container-open",
+    "container-close",
+    "tag",
+  ]).isRequired,
   tagName: PropTypes.string.isRequired,
   text: PropTypes.string,
-  isSubChallenge: PropTypes.bool.isRequired,
-  isContainer: PropTypes.bool.isRequired,
-  type: PropTypes.string,
-  title: PropTypes.string.isRequired,
 };
 
 HighlightedTag.defaultProps = {
   text: "",
-  type: "",
 };
+
+const Tag = styled.span`
+  .stage {
+    color: ${({ theme }) => theme.color.challengeTag};
+  }
+
+  .container {
+    color: ${({ theme }) => theme.color.parentTag};
+  }
+
+  .tag {
+    color: ${({ theme }) => theme.color.childTag};
+  }
+`;
 
 export default HighlightedTag;

--- a/src/components/Challenge/DndInterface/Preview/index.jsx
+++ b/src/components/Challenge/DndInterface/Preview/index.jsx
@@ -21,19 +21,19 @@ function Preview({
 
   return (
     <PreviewWrapper className={className} top={top} left={left} onClick={onClick}>
-      <div className="preview-element">
+      <PreviewElement>
         <ElementBlock
           _id="preview"
           block={block}
           childTrees={previewChildTrees}
         />
-      </div>
-      <div className="preview-style">
+      </PreviewElement>
+      <PreviewStyleProperty>
         <a href={refURL}>{block.tagName}</a>
         {styles.map(([key, value]) => (
-          <p key={key}>{`${key}: ${value};`}</p>
+          <PreviewStylePair key={key}>{`${key}: ${value};`}</PreviewStylePair>
         ))}
-      </div>
+      </PreviewStyleProperty>
     </PreviewWrapper>
   );
 }
@@ -71,8 +71,6 @@ Preview.defaultProps = {
   className: "",
 };
 
-export default Preview;
-
 const PreviewWrapper = styled.div`
   display: grid;
   position: absolute;
@@ -84,26 +82,28 @@ const PreviewWrapper = styled.div`
   padding: 10px;
   background-color: ${({ theme }) => theme.color.preview};
   justify-content: start;
-
-  .preview-element {
-    position: relative;
-    display: flex;
-    margin: auto;
-    padding: 10px;
-    background-color: white;
-    justify-content: center;
-    align-items: center;
-  }
-
-  .preview-style {
-    width: 100%;
-    max-height: 30px;
-    margin: 5px;
-    padding: 5px;
-    color: white;
-
-    p {
-      padding: 2px;
-    }
-  }
 `;
+
+const PreviewElement = styled.div`
+  position: relative;
+  display: flex;
+  margin: auto;
+  padding: 10px;
+  background-color: white;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PreviewStyleProperty = styled.div`
+  width: 100%;
+  max-height: 30px;
+  margin: 5px;
+  padding: 5px;
+  color: white;
+`;
+
+const PreviewStylePair = styled.p`
+  padding: 2px;
+`;
+
+export default Preview;

--- a/src/components/Challenge/DndInterface/Preview/index.jsx
+++ b/src/components/Challenge/DndInterface/Preview/index.jsx
@@ -6,12 +6,12 @@ import ElementBlock from "../../Display/ElementBlock";
 import { convertCamelToKebab, calcPosition } from "../../../../helpers/dataFormatters";
 
 function Preview({
-  isSubChallenge, block, childTrees, position, className, onClick,
+  tagType, block, childTrees, position, className, onClick,
 }) {
   const styles = Object.entries(block?.property?.style || {})
     .map(([key, value]) => [convertCamelToKebab(key), value])
     .sort((a, b) => b[0] > a[0]);
-  const previewChildTrees = !isSubChallenge && block.isContainer && childTrees.length
+  const previewChildTrees = tagType === "container" && !childTrees.length
     ? [{ _id: "virtualChild", block: { tagName: "span", property: { text: "child" }, isContainer: false } }]
     : childTrees;
   const { top, left } = calcPosition(position, { width: 300, height: 150 });
@@ -39,7 +39,7 @@ function Preview({
 }
 
 export const tagBlockSchema = {
-  isSubChallenge: PropTypes.bool.isRequired,
+  tagType: PropTypes.oneOf(["stage", "container", "tag"]),
   block: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     tagName: PropTypes.string.isRequired,

--- a/src/components/Challenge/DndInterface/Preview/index.jsx
+++ b/src/components/Challenge/DndInterface/Preview/index.jsx
@@ -1,13 +1,20 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
 import ElementBlock from "../../Display/ElementBlock";
+
+import { selectBlockTreeById } from "../../../../helpers/globalSelectors";
 import { convertCamelToKebab, calcPosition } from "../../../../helpers/dataFormatters";
 
 function Preview({
-  tagType, block, childTrees, position, className, onClick,
+  _id, containerId, position, onClick,
 }) {
+  const blockTree = useSelector(
+    (state) => selectBlockTreeById(state, containerId, _id),
+  );
+  const { block, tagType, childTrees } = blockTree;
   const styles = Object.entries(block?.property?.style || {})
     .map(([key, value]) => [convertCamelToKebab(key), value])
     .sort((a, b) => b[0] > a[0]);
@@ -20,7 +27,7 @@ function Preview({
     : `${process.env.REACT_APP_REF_URI}/${block.tagName}`;
 
   return (
-    <PreviewWrapper className={className} top={top} left={left} onClick={onClick}>
+    <PreviewWrapper top={top} left={left} onClick={onClick}>
       <PreviewElement>
         <ElementBlock
           _id="preview"
@@ -38,37 +45,14 @@ function Preview({
   );
 }
 
-export const tagBlockSchema = {
-  tagType: PropTypes.oneOf(["stage", "container", "tag"]),
-  block: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    tagName: PropTypes.string.isRequired,
-    isContainer: PropTypes.bool.isRequired,
-    property: PropTypes.objectOf(
-      PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.objectOf(PropTypes.string),
-      ]).isRequired,
-    ).isRequired,
-  }).isRequired,
-};
-
 Preview.propTypes = {
-  ...tagBlockSchema,
-  childTrees: PropTypes.arrayOf(
-    PropTypes.shape(tagBlockSchema),
-  ),
-  className: PropTypes.string,
+  _id: PropTypes.string.isRequired,
+  containerId: PropTypes.string.isRequired,
   position: PropTypes.shape({
     top: PropTypes.number.isRequired,
     left: PropTypes.number.isRequired,
   }).isRequired,
   onClick: PropTypes.func.isRequired,
-};
-
-Preview.defaultProps = {
-  childTrees: [],
-  className: "",
 };
 
 const PreviewWrapper = styled.div`

--- a/src/components/Challenge/DndInterface/TagBlock/index.jsx
+++ b/src/components/Challenge/DndInterface/TagBlock/index.jsx
@@ -8,7 +8,7 @@ import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function TagBlock({
   _id, type, containerId, className, onMouseOver, onMouseOut, onClick,
-  tagName, text, isSubChallenge, isContainer,
+  tagName, text, isSubChallenge, isContainer, title,
 }) {
   const ref = useRef(null);
   const handleSelect = (func) => {
@@ -35,6 +35,7 @@ function TagBlock({
           text={text}
           isSubChallenge={isSubChallenge}
           isContainer={isContainer}
+          title={title}
         />
       </TagBlockWrapper>
     </Draggable>
@@ -53,6 +54,7 @@ TagBlock.propTypes = {
   onMouseOver: PropTypes.func.isRequired,
   onMouseOut: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 const TagBlockWrapper = styled.div`

--- a/src/components/Challenge/DndInterface/TagBlock/index.jsx
+++ b/src/components/Challenge/DndInterface/TagBlock/index.jsx
@@ -60,21 +60,4 @@ const TagBlockWrapper = styled.div`
   background-color: ${({ theme }) => theme.color.point};
 `;
 
-const tagBlockSchema = {
-  _id: PropTypes.string.isRequired,
-  isSubChallenge: PropTypes.bool.isRequired,
-  block: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    tagName: PropTypes.string.isRequired,
-    isContainer: PropTypes.bool.isRequired,
-    property: PropTypes.objectOf(
-      PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.objectOf(PropTypes.string),
-      ]).isRequired,
-    ).isRequired,
-  }).isRequired,
-};
-
-export { tagBlockSchema };
 export default TagBlock;

--- a/src/components/Challenge/DndInterface/TagBlock/index.jsx
+++ b/src/components/Challenge/DndInterface/TagBlock/index.jsx
@@ -8,7 +8,7 @@ import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function TagBlock({
   _id, type, containerId, className, onMouseOver, onMouseOut, onClick,
-  tagName, text, isSubChallenge, isContainer, title,
+  tagName, text, tagType,
 }) {
   const ref = useRef(null);
   const handleSelect = (func) => {
@@ -31,11 +31,9 @@ function TagBlock({
         onClick={() => handleSelect(onClick)}
       >
         <HighlightedTag
+          tagType={tagType}
           tagName={tagName}
           text={text}
-          isSubChallenge={isSubChallenge}
-          isContainer={isContainer}
-          title={title}
         />
       </TagBlockWrapper>
     </Draggable>
@@ -45,16 +43,14 @@ function TagBlock({
 TagBlock.propTypes = {
   _id: PropTypes.string.isRequired,
   tagName: PropTypes.string.isRequired,
+  tagType: PropTypes.oneOf(["stage", "container", "tag"]).isRequired,
   text: PropTypes.string.isRequired,
-  isSubChallenge: PropTypes.bool.isRequired,
-  isContainer: PropTypes.bool.isRequired,
   type: PropTypes.oneOf(Object.values(DRAGGABLE_TYPE)).isRequired,
   containerId: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   onMouseOver: PropTypes.func.isRequired,
   onMouseOut: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
 };
 
 const TagBlockWrapper = styled.div`

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -63,8 +63,8 @@ function DndInterface({ onDrop, className }) {
             _id, block, title, tagType,
           }) => (
             <TagBlock
-              _id={_id}
               key={_id}
+              _id={_id}
               containerId={TYPE.TAG_BLOCK_CONTAINER}
               tagName={block.tagName}
               tagType={tagType}
@@ -74,7 +74,6 @@ function DndInterface({ onDrop, className }) {
               onMouseOver={(data) => onPick(data, "hover")}
               onMouseOut={onUnpick}
               onClick={(data) => onPick(data, "click")}
-              title={title}
             />
           ))}
         </TagBlockContainer>

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -11,18 +11,6 @@ import Preview from "./Preview";
 import { usePick } from "../../../hooks/usePick";
 import { TYPE, DRAGGABLE_TYPE } from "../../../constants";
 
-function getTagType(isSubChallenge, isContainer) {
-  if (isSubChallenge) {
-    return "stage";
-  }
-
-  if (isContainer) {
-    return "container";
-  }
-
-  return "tag";
-}
-
 function DndInterface({
   tagBlockContainer, boilerplate, onDrop, className,
 }) {
@@ -74,15 +62,15 @@ function DndInterface({
         />
         <div className="flex-wrap">
           {tagBlockContainer.childTrees.map(({
-            _id, block, isSubChallenge, title,
+            _id, block, title, tagType,
           }) => (
             <TagBlock
               _id={_id}
               key={_id}
               containerId={TYPE.TAG_BLOCK_CONTAINER}
               tagName={block.tagName}
-              tagType={getTagType(isSubChallenge, block.isContainer)}
-              text={isSubChallenge ? title : block.property.text || ""}
+              tagType={tagType}
+              text={tagType === "stage" ? title : block.property.text || ""}
               className={`tag-block ${picked._id === _id ? "selected-tag-block" : "swing"}`}
               type={block.isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
               onMouseOver={(data) => onPick(data, "hover")}

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -11,6 +11,18 @@ import Preview from "./Preview";
 import { usePick } from "../../../hooks/usePick";
 import { TYPE, DRAGGABLE_TYPE } from "../../../constants";
 
+function getTagType(isSubChallenge, isContainer) {
+  if (isSubChallenge) {
+    return "stage";
+  }
+
+  if (isContainer) {
+    return "container";
+  }
+
+  return "tag";
+}
+
 function DndInterface({
   tagBlockContainer, boilerplate, onDrop, className,
 }) {
@@ -69,9 +81,8 @@ function DndInterface({
               key={_id}
               containerId={TYPE.TAG_BLOCK_CONTAINER}
               tagName={block.tagName}
-              isSubChallenge={isSubChallenge}
-              isContainer={block.isContainer}
-              text={block.property.text || ""}
+              tagType={getTagType(isSubChallenge, block.isContainer)}
+              text={isSubChallenge ? title : block.property.text || ""}
               className={`tag-block ${picked._id === _id ? "selected-tag-block" : "swing"}`}
               type={block.isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
               onMouseOver={(data) => onPick(data, "hover")}
@@ -144,20 +155,8 @@ const DndInterfaceWrapper = styled.div`
     background-color: ${({ theme }) => theme.color.point};
   }
 
-  .challenge-tag {
-    color: ${({ theme }) => theme.color.challengeTag};
-  }
-
-  .parent-tag {
-    color: ${({ theme }) => theme.color.parentTag};
-  }
-
   .selected-tag {
     color: ${({ theme }) => theme.color.point};
-  }
-
-  .child-tag {
-    color: ${({ theme }) => theme.color.childTag};
   }
 `;
 
@@ -167,9 +166,8 @@ const TagBlockContainer = styled.div`
   padding: 10px;
   justify-content: center;
   align-items: center;
-  border-top: 1px solid ${({ theme }) => theme.color.border};
-  border-right: 1px solid ${({ theme }) => theme.color.border};
-  border-bottom: 1px solid ${({ theme }) => theme.color.border};
+  border: 1px solid ${({ theme }) => theme.color.border};
+  border-left: none;
 
   .tag-block-container-drop-area {
     position: absolute;
@@ -197,9 +195,8 @@ const HTMLViewer = styled.div`
   display: grid;
   grid-template-columns: 30px auto;
   align-items: center;
-  border-top: 1px solid ${({ theme }) => theme.color.border};
-  border-right: 1px solid ${({ theme }) => theme.color.border};
-  border-bottom: 1px solid ${({ theme }) => theme.color.border};
+  border: 1px solid ${({ theme }) => theme.color.border};
+  border-left: none;
   counter-reset: line;
 
   @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}), {

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -1,19 +1,20 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 import CustomDragLayer from "./CustomDragLayer";
-import TagBlock, { tagBlockSchema } from "./TagBlock";
+import TagBlock from "./TagBlock";
 import DropArea from "./DropArea";
 import DropContainer from "./DropContainer";
 import Preview from "./Preview";
 
+import { selectStage } from "../../../helpers/globalSelectors";
 import { usePick } from "../../../hooks/usePick";
 import { TYPE, DRAGGABLE_TYPE } from "../../../constants";
 
-function DndInterface({
-  tagBlockContainer, boilerplate, onDrop, className,
-}) {
+function DndInterface({ onDrop, className }) {
+  const stage = useSelector(selectStage);
   const {
     picked, onPick, onUnpick, onReset,
   } = usePick();
@@ -60,7 +61,7 @@ function DndInterface({
           onClick={handleClickDrop}
         />
         <TagBlockContainer>
-          {tagBlockContainer.childTrees.map(({
+          {stage.tagBlockContainer.childTrees.map(({
             _id, block, title, tagType,
           }) => (
             <TagBlock
@@ -83,17 +84,13 @@ function DndInterface({
       <HTMLViewer>
         <LineNumberSpace />
         <DropContainer
-          _id={boilerplate._id}
-          containerId={boilerplate._id}
-          childTrees={boilerplate.childTrees}
-          tagName={boilerplate.block.tagName}
-          isSubChallenge
+          _id={stage.boilerplate._id}
+          containerId=""
           onDrop={handleDrop}
           onClick={handleClickDrop}
           onBlockClick={(data) => onPick(data, "click")}
           selectedTagId={picked._id}
           isDropAreaActive={!!picked._id}
-          title={boilerplate.title}
         />
       </HTMLViewer>
     </DndInterfaceWrapper>
@@ -101,23 +98,6 @@ function DndInterface({
 }
 
 DndInterface.propTypes = {
-  tagBlockContainer: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
-    childTrees: PropTypes.arrayOf(
-      PropTypes.shape(tagBlockSchema),
-    ).isRequired,
-  }).isRequired,
-  boilerplate: PropTypes.shape({
-    title: PropTypes.string.isRequired,
-    _id: PropTypes.string.isRequired,
-    childTrees: PropTypes.arrayOf(
-      PropTypes.shape(tagBlockSchema),
-    ).isRequired,
-    block: PropTypes.shape({
-      _id: PropTypes.string.isRequired,
-      tagName: PropTypes.string.isRequired,
-    }),
-  }).isRequired,
   onDrop: PropTypes.func.isRequired,
   className: PropTypes.string,
 };

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -61,7 +61,9 @@ function DndInterface({
           className="tag-block-container-drop-area"
         />
         <div className="flex-wrap">
-          {tagBlockContainer.childTrees.map(({ _id, block, isSubChallenge }) => (
+          {tagBlockContainer.childTrees.map(({
+            _id, block, isSubChallenge, title,
+          }) => (
             <TagBlock
               _id={_id}
               key={_id}
@@ -75,6 +77,7 @@ function DndInterface({
               onMouseOver={(data) => onPick(data, "hover")}
               onMouseOut={onUnpick}
               onClick={(data) => onPick(data, "click")}
+              title={title}
             />
           ))}
         </div>
@@ -92,6 +95,7 @@ function DndInterface({
           onBlockClick={(data) => onPick(data, "click")}
           selectedTagId={picked._id}
           isDropAreaActive={!!picked._id}
+          title={boilerplate.title}
         />
       </HTMLViewer>
     </DndInterfaceWrapper>
@@ -106,6 +110,7 @@ DndInterface.propTypes = {
     ).isRequired,
   }).isRequired,
   boilerplate: PropTypes.shape({
+    title: PropTypes.string.isRequired,
     _id: PropTypes.string.isRequired,
     childTrees: PropTypes.arrayOf(
       PropTypes.shape(tagBlockSchema),

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -42,7 +42,7 @@ function DndInterface({
   return (
     <DndInterfaceWrapper className={className}>
       <CustomDragLayer />
-      <TagBlockContainer>
+      <TagBlockShowcase>
         {picked.enablePreview && (
         <Preview
           tagType={picked.tagType}
@@ -53,14 +53,13 @@ function DndInterface({
           onClick={onUnpick}
         />
         )}
-        <DropArea
+        <TagBlockShowcaseDropArea
           _id={TYPE.TAG_BLOCK_CONTAINER}
           index={-1}
           onDrop={handleDrop}
           onClick={handleClickDrop}
-          className="tag-block-container-drop-area"
         />
-        <div className="flex-wrap">
+        <TagBlockContainer>
           {tagBlockContainer.childTrees.map(({
             _id, block, title, tagType,
           }) => (
@@ -71,7 +70,7 @@ function DndInterface({
               tagName={block.tagName}
               tagType={tagType}
               text={tagType === "stage" ? title : block.property.text || ""}
-              className={`tag-block ${picked._id === _id ? "selected-tag-block" : "swing"}`}
+              className={picked._id === _id ? "selected-tag-block" : "swing"}
               type={block.isContainer ? DRAGGABLE_TYPE.CONTAINER : DRAGGABLE_TYPE.TAG}
               onMouseOver={(data) => onPick(data, "hover")}
               onMouseOut={onUnpick}
@@ -79,8 +78,8 @@ function DndInterface({
               title={title}
             />
           ))}
-        </div>
-      </TagBlockContainer>
+        </TagBlockContainer>
+      </TagBlockShowcase>
       <HTMLViewer>
         <LineNumberSpace />
         <DropContainer
@@ -140,7 +139,7 @@ const DndInterfaceWrapper = styled.div`
 
   .dragging .swing {
     animation: none;
-    background-color: ${({ theme }) => theme.color.point};
+    background-color: ${({ theme }) => theme.color.preview};
   }
 
   .selected-tag {
@@ -148,7 +147,7 @@ const DndInterfaceWrapper = styled.div`
   }
 `;
 
-const TagBlockContainer = styled.div`
+const TagBlockShowcase = styled.div`
   position: relative;
   display: flex;
   padding: 10px;
@@ -156,24 +155,21 @@ const TagBlockContainer = styled.div`
   align-items: center;
   border: 1px solid ${({ theme }) => theme.color.border};
   border-left: none;
+`;
 
-  .tag-block-container-drop-area {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-  }
+const TagBlockShowcaseDropArea = styled(DropArea)`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+`;
 
-  .flex-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .tag-block {
-    position: relative;
-  }
+const TagBlockContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 
   .selected-tag-block {
+    position: relative;
     background-color: ${({ theme }) => theme.color.preview};
   }
 `;
@@ -193,17 +189,6 @@ const HTMLViewer = styled.div`
 
   .dragging * {
     color: ${({ theme }) => theme.color.point};
-  }
-
-  .tag-text::before {
-    position: absolute;
-    right: 100%;
-    margin-right: -20px;
-    text-align: right;
-    font-size: 0.8rem;
-    counter-increment: line;
-    content: counter(line);
-    color: ${({ theme }) => theme.color.inactive};
   }
 `;
 

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -44,15 +44,13 @@ function DndInterface({ onDrop, className }) {
     <DndInterfaceWrapper className={className}>
       <CustomDragLayer />
       <TagBlockShowcase>
-        {picked.enablePreview && (
-        <Preview
-          tagType={picked.tagType}
-          block={picked.block}
-          childTrees={picked.childTrees}
-          className="preview"
-          position={picked.position}
-          onClick={onUnpick}
-        />
+        {picked.position && (
+          <Preview
+            _id={picked._id}
+            containerId={picked.containerId}
+            position={picked.position}
+            onClick={onUnpick}
+          />
         )}
         <TagBlockShowcaseDropArea
           _id={TYPE.TAG_BLOCK_CONTAINER}

--- a/src/components/Challenge/DndInterface/index.jsx
+++ b/src/components/Challenge/DndInterface/index.jsx
@@ -45,7 +45,7 @@ function DndInterface({
       <TagBlockContainer>
         {picked.enablePreview && (
         <Preview
-          isSubChallenge={picked.isSubChallenge}
+          tagType={picked.tagType}
           block={picked.block}
           childTrees={picked.childTrees}
           className="preview"

--- a/src/components/Challenge/index.jsx
+++ b/src/components/Challenge/index.jsx
@@ -84,25 +84,19 @@ function Challenge() {
   ]);
 
   return (
-    <PuzzleWrapper>
+    <ChallengeWrapper>
       {canRender && (
         <>
-          <Display boilerplate={stage.boilerplate} elementTree={stage.elementTree} />
-          <DndInterface
-            tagBlockContainer={stage.tagBlockContainer}
-            boilerplate={stage.boilerplate}
-            onDrop={handleDrop}
-          />
+          <Display />
+          <DndInterface onDrop={handleDrop} />
           <ResetButton value="reset" onClick={handleReset} />
         </>
       )}
-    </PuzzleWrapper>
+    </ChallengeWrapper>
   );
 }
 
-export default Challenge;
-
-const PuzzleWrapper = styled.div`
+const ChallengeWrapper = styled.div`
   display: grid;
   width: 100%;
   height: 100%;
@@ -129,3 +123,5 @@ const ResetButton = styled(Button)`
     background-color: ${({ theme }) => theme.color.point};
   }
 `;
+
+export default Challenge;

--- a/src/components/Header/StageList/index.jsx
+++ b/src/components/Header/StageList/index.jsx
@@ -50,8 +50,6 @@ StageList.propTypes = {
   stageId: PropTypes.string.isRequired,
 };
 
-export default StageList;
-
 const Li = styled.li`
   margin: 5px 0px 5px 15px;
 
@@ -59,3 +57,5 @@ const Li = styled.li`
     background-color: ${({ theme }) => theme.color.point};
   }
 `;
+
+export default StageList;

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -72,8 +72,6 @@ Header.propTypes = {
   onStageMenuClick: PropTypes.func.isRequired,
 };
 
-export default Header;
-
 const HeaderWrapper = styled.header`
   display: flex;
   position: relative;
@@ -134,3 +132,5 @@ const ChallengeListWrapper = styled(ListWrapper)`
     background-color: ${({ theme }) => theme.color.point};
   }
 `;
+
+export default Header;

--- a/src/components/NoticeModal/index.jsx
+++ b/src/components/NoticeModal/index.jsx
@@ -54,8 +54,6 @@ NoticeModal.propTypes = {
   onReset: PropTypes.func.isRequired,
 };
 
-export default NoticeModal;
-
 const Wrapper = styled(Modal)`
   color: ${({ theme }) => theme.color.main};
 
@@ -108,3 +106,5 @@ const ClickInterface = styled.div`
     font-size: 0.8rem;
   }
 `;
+
+export default NoticeModal;

--- a/src/components/Tutorial/index.jsx
+++ b/src/components/Tutorial/index.jsx
@@ -92,8 +92,6 @@ function Tutorial() {
   );
 }
 
-export default Tutorial;
-
 const TutorialWrapper = styled.div`
   display: grid;
   width: 100%;
@@ -121,3 +119,5 @@ const Guide = styled.div`
     font-size: 0.8rem;
   }
 `;
+
+export default Tutorial;

--- a/src/components/shared/Modal/index.jsx
+++ b/src/components/shared/Modal/index.jsx
@@ -30,8 +30,6 @@ Modal.defaultProps = {
   onClick: () => {},
 };
 
-export default Modal;
-
 const Wrapper = styled.div`
   position: absolute;
   display: flex;
@@ -62,3 +60,5 @@ const ModalWrapper = styled.div`
   text-align: center;
   background-color: ${({ theme }) => theme.color.inner};
 `;
+
+export default Modal;

--- a/src/helpers/globalSelectors.js
+++ b/src/helpers/globalSelectors.js
@@ -9,11 +9,19 @@ function selectContainer(stage, containerId) {
   return findBlockTreeById(stage.boilerplate, containerId);
 }
 
+function selectStage(state) {
+  const { challenges, selectedIndex } = state.challenge;
+  const challenge = challenges[selectedIndex];
+  const stage = findBlockTreeById(challenge.elementTree, challenge.stageId);
+
+  return stage;
+}
+
 function selectBlockTreeById(state, containerId, id) {
   const { challenges, selectedIndex } = state.challenge;
   const challenge = challenges[selectedIndex];
   const stage = findBlockTreeById(challenge.elementTree, challenge.stageId);
-  const container = selectContainer(stage, containerId);
+  const container = containerId ? selectContainer(stage, containerId) : stage.boilerplate;
 
   return findBlockTreeById(container, id);
 }
@@ -78,6 +86,7 @@ function selectStageByParams(state, { index, id }) {
 
 export {
   selectContainer,
+  selectStage,
   selectStageByParams,
   selectBlockTreeById,
 };

--- a/src/helpers/tagBlockGenerators.js
+++ b/src/helpers/tagBlockGenerators.js
@@ -10,6 +10,48 @@ function getTagType(isSubChallenge, isContainer) {
   return "tag";
 }
 
+function validateBlockTree(node) {
+  if (typeof node !== "object" || node === null) {
+    return false;
+  }
+
+  const { _id, isSubChallenge, block } = node;
+
+  if (typeof _id !== "string" || !_id) {
+    return false;
+  }
+
+  if (typeof isSubChallenge !== "boolean") {
+    return false;
+  }
+
+  if (block === null || typeof block !== "object") {
+    return null;
+  }
+
+  const {
+    _id: blockId, tagName, isContainer, property,
+  } = block;
+
+  if (typeof blockId !== "string" || !blockId) {
+    return false;
+  }
+
+  if (typeof tagName !== "string" || !tagName) {
+    return false;
+  }
+
+  if (typeof isContainer !== "boolean") {
+    return false;
+  }
+
+  if (typeof property !== "object" || property === null) {
+    return false;
+  }
+
+  return true;
+}
+
 function generateBlocks(elementTree, onlySubChallenge = true) {
   const queue = [...elementTree.childTrees];
   const blocks = [];
@@ -19,7 +61,11 @@ function generateBlocks(elementTree, onlySubChallenge = true) {
     const condition = onlySubChallenge ? !currentNode.isSubChallenge : true;
     const tagType = getTagType(currentNode.isSubChallenge, currentNode.block.isContainer);
 
-    if (condition && currentNode.block.isContainer) {
+    if (!validateBlockTree(currentNode)) {
+      if (process.env.NODE_ENV === "development") {
+        console.error(`tag block type error ${JSON.stringify(currentNode, null, 2)}`);
+      }
+    } else if (condition && currentNode.block.isContainer) {
       blocks.push({
         ...currentNode,
         tagType,

--- a/src/helpers/tagBlockGenerators.js
+++ b/src/helpers/tagBlockGenerators.js
@@ -26,7 +26,7 @@ function validateBlockTree(node) {
   }
 
   if (block === null || typeof block !== "object") {
-    return null;
+    return false;
   }
 
   const {

--- a/src/helpers/tagBlockGenerators.js
+++ b/src/helpers/tagBlockGenerators.js
@@ -1,3 +1,15 @@
+function getTagType(isSubChallenge, isContainer) {
+  if (isSubChallenge) {
+    return "stage";
+  }
+
+  if (isContainer) {
+    return "container";
+  }
+
+  return "tag";
+}
+
 function generateBlocks(elementTree, onlySubChallenge = true) {
   const queue = [...elementTree.childTrees];
   const blocks = [];
@@ -5,15 +17,20 @@ function generateBlocks(elementTree, onlySubChallenge = true) {
   while (queue.length) {
     const currentNode = queue.shift();
     const condition = onlySubChallenge ? !currentNode.isSubChallenge : true;
+    const tagType = getTagType(currentNode.isSubChallenge, currentNode.block.isContainer);
 
     if (condition && currentNode.block.isContainer) {
       blocks.push({
         ...currentNode,
+        tagType,
         childTrees: [],
       });
       queue.push(...currentNode.childTrees);
     } else {
-      blocks.push(currentNode);
+      blocks.push({
+        tagType,
+        ...currentNode,
+      });
     }
   }
 

--- a/src/hooks/usePick.js
+++ b/src/hooks/usePick.js
@@ -1,7 +1,4 @@
 import { useState } from "react";
-import { useSelector } from "react-redux";
-
-import { selectBlockTreeById } from "../helpers/globalSelectors";
 
 const initialPicked = {
   _id: "",
@@ -13,9 +10,6 @@ const initialPicked = {
 
 function usePick() {
   const [picked, setPicked] = useState(initialPicked);
-  const pickedBlockTree = useSelector(
-    (state) => selectBlockTreeById(state, picked.containerId, picked._id),
-  );
   const handleReset = () => setPicked(initialPicked);
   const handleUnpick = () => {
     if (picked.isClicked) {
@@ -52,9 +46,7 @@ function usePick() {
   };
 
   return {
-    picked: pickedBlockTree
-      ? { ...picked, ...pickedBlockTree, enablePreview: !!picked.position }
-      : picked,
+    picked,
     onPick: handlePick,
     onUnpick: handleUnpick,
     onReset: handleReset,


### PR DESCRIPTION
closes #75 
아래와 같이 DndInterface 리팩토링 작업하였습니다.

### HighlightedTag 컴포넌트
  - tagType prop
    - highlight 방식을 결정하기 위해 필요했던 prop 3종(isSubChallenge, isContainer, type)이 tagType prop으로 대체되면서, 관련 중복이 제거되었습니다.
    - tagType은 initializeStage 단계에서 실행되는 tagBlockGenerators에서 blockTree에 추가됩니다. 
    - 현재 tagType은 총 5가지 입니다. [stage, container, container-open, container-close, tag]
  - text prop
    - stage 태그인 경우 (일종의 부모 태그이기 때문에) text property 대신 title을 표시하는데, 이는 HighlightedTag를 호출하는 부모 컴포넌트(CustomDragLayer, DropContainer)에서 판단 후 text prop으로 넘겨줍니다.
    - CustomDragLayer에서 사용되는 드래그 프리뷰가 HighlightedTag로 고정되어, 기존 자체 스타일은 제거하였습니다.

### Display, DndInterface 컴포넌트
  - prop -> useSelector: stage 데이터(boilerplate, elementTree)를 받아오는 방식을 변경하였습니다.
  - 데이터를 선택하기 위한 selectStage 함수를 globalSelectors에 추가하였습니다.

### DropContainer, Preview 컴포넌트
  - prop -> useSelector: blockTree 데이터를 받아오는 방식을 변경하였습니다.
  - Preview에서 blockTree 데이터를 넘겨주기 위한 로직이었던 usePick hook의 useSelector 관련 로직을 제거하였습니다.

### TagBlock의 tagBlockSchema 삭제 및 tagBlockGenerators에 validateBlockTree 추가
  - tagBlockSchema는 blockTree 데이터를 prop으로 넘기는 경우, nested childTrees의 propTypes를 재귀적으로 처리하기 위해 TagBlock 컴포넌트 쪽에서 export 하던 PropType 객체입니다.
  - 위의 Display, DndInterface, DropContainer, Preview에서 useSelector를 사용하게 되면서 더 이상 tagBlockSchema가 필요하지 않게 되어 삭제하였습니다.
  - tagBlockSchema를 삭제하면서, 최초 tagBlockGenerators 실행시 validate를 위한 함수를 추가하였습니다.
  - validate에 실패하는 경우 해당 블록은 추가되지 않습니다. 이에 더해, 개발모드인 경우 해당 blockTree 정보를 출력해줍니다.

### className 관련 리팩토링
  - 고정적인 className이 부여되는 컴포넌트를 별도의 styled-component로 분리하였습니다.
    - DropContainer의 .tag-text를 TagText 컴포넌트로 분리 후, TagText의 :before 가상클래스 스타일을 해당 styled-component 내부로 이동하였습니다.
    - DropContainer에서 DropArea의 margin 값에 차이를 주기 위해 사용되었던 className은 inherited styeld-component(FirstDropArea, BackwardDropArea)로 대체하였습니다. 
    - Preview 내부에서 className으로 관리되던 .element, .style 태그를 별도 컴포넌트로 분리하였습니다.
    - DndInterface에서 TagBlockContainer 관련 styled-component 명칭 변경하였습니다. (최상단을 TagBlockShowcase로 변경 후, map 실행단을 TagBlockContainer로 하였습니다.)

### 기타 수정사항
- 몇몇 컴포넌트에서 styled component 선언문 위쪽에 위치하던 export 구문을 최하단으로 이동하였습니다.
- 자식이 추가된 태그를 TagBlockContainer으로 옮기는 경우 (아래 이미지 참조), 추가된 자식이 Preview에 함께 표시되도록 수정하였습니다.
![previewWithChildTrees](https://user-images.githubusercontent.com/60309558/139231028-f9aea54c-af11-48fe-a5da-e53bf45262bf.gif)

