### PR TITLE
Fix: drop guide animation timing error

### DIFF
--- a/src/components/Challenge/DndInterface/DropArea/index.jsx
+++ b/src/components/Challenge/DndInterface/DropArea/index.jsx
@@ -33,7 +33,7 @@ function DropArea({
   return (
     <Area
       ref={dropRef}
-      className={`${className} ${hovered ? "animation-none" : ""}`}
+      className={className}
       isHighlighted={hovered && needHighlight}
       onClick={handleClick}
     />
@@ -56,9 +56,18 @@ DropArea.defaultProps = {
 };
 
 const Area = styled.div`
+  position: relative;
   padding: 2px 0;
-  background-color: ${({ isHighlighted, theme }) => (isHighlighted ? theme.color.preview : "transparent")};
   cursor: pointer;
+
+  ::after {
+    position: absolute;
+    width: 100%;
+    padding: 2px;
+    margin-top: -2px;
+    background-color: ${({ isHighlighted, theme }) => (isHighlighted ? theme.color.preview : "transparent")};
+    content: " ";
+  }
 `;
 
 export default DropArea;

--- a/src/theme/global.js
+++ b/src/theme/global.js
@@ -38,21 +38,9 @@ const GlobalStyle = createGlobalStyle`
     animation: 0.15s ease-in-out 0s infinite alternate swing;
   }
 
-  .correct {
-    animation: 0.2s ease-in-out 0.1s 2 correctBlink;
-  }
-
-  .wrong {
-    animation: 0.2s ease-in-out 0.1s 2 errorBlink;
-  }
-
   .grow-down {
     animation: 0.25s ease-in-out 0s 1 alternate growDown;
     transform-origin: top center;
-  }
-
-  .animation-none {
-    animation: none;
   }
 
   @keyframes blink {
@@ -65,29 +53,6 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
-  @keyframes correctBlink {
-    to {
-      background-color: transparent;
-      transform: scaleY(2);
-    }
-
-    to {
-      background-color: ${theme.color.dropGuide};
-      transform: scaleY(1);
-    }
-  }
-
-  @keyframes errorBlink {
-    to {
-      background-color: transparent;
-      transform: scaleY(2);
-    }
-
-    to {
-      background-color: ${theme.color.errorBackground};
-      transform: scaleY(1);
-    }
-  }
 
   @keyframes swing {
     0%, 25% {


### PR DESCRIPTION
### 이전
drop area가 hover되고 나면 각 drop area에 적용된 애니메이션 시작 시점이 변경되는 이슈가 있었습니다.
![dropGuideAnimation_before](https://user-images.githubusercontent.com/60309558/146787590-dab86731-bd0d-4509-a5f9-3f6b1720ffda.gif)

### 이후
drop area가 hover된 이후에도 애니메이션 타이밍이 변경되지 않습니다.
![dropGuideAnimation_after](https://user-images.githubusercontent.com/60309558/146787557-893d4876-ff0c-437d-b849-9aa54209b59e.gif)
- [ ] 애니메이션 싱크에 대한 근본적인 해결책(아마도 구조 변경)이 필요합니다.
  - 현재는 css의 after 가상클래스를 이용해 hover 시 애니메이션 위에 덮어쓴 상태입니다. 실제 애니메이션 싱크 문제는 해결되지 않았으며, 애니메이션이 중단되는 시점을 없애서 임시로 (그리고 시각적으로만) 해결되었습니다.


- 사용되지 않는 CSS 클래스와 관련 애니메이션을 정리하였습니다.
  - .correct, .wrong, correctBlink/errorBlink keyframe
  - .animation-none