### PR TITLE
Modify: drag preview position

### DIFF
--- a/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
+++ b/src/components/Challenge/DndInterface/CustomDragLayer/index.jsx
@@ -9,12 +9,12 @@ import { getItemStyles } from "../../../../helpers/dataFormatters";
 
 function CustomDragLayer() {
   const {
-    isDragging, item, initialOffset, currentOffset,
+    isDragging, item, initialOffset, clientOffset,
   } = useDragLayer((monitor) => ({
     item: monitor.getItem(),
     itemType: monitor.getItemType(),
     initialOffset: monitor.getInitialSourceClientOffset(),
-    currentOffset: monitor.getSourceClientOffset(),
+    clientOffset: monitor.getClientOffset(),
     isDragging: monitor.isDragging(),
   }));
   const blockTree = useSelector(
@@ -27,7 +27,7 @@ function CustomDragLayer() {
 
   return (
     <Layer>
-      <span style={getItemStyles(initialOffset, currentOffset)}>
+      <TagWrapper style={getItemStyles(initialOffset, clientOffset)}>
         {blockTree && (
         <HighlightedTag
           tagType={blockTree.tagType}
@@ -35,7 +35,7 @@ function CustomDragLayer() {
           text={blockTree.tagType === "stage" ? blockTree.title : blockTree.block.property.text}
         />
         )}
-      </span>
+      </TagWrapper>
     </Layer>
   );
 }
@@ -49,6 +49,10 @@ const Layer = styled.div`
   top: 0;
   width: 100%;
   height: 100%;
+`;
+
+const TagWrapper = styled.div`
+  position: fixed;
 `;
 
 export default CustomDragLayer;

--- a/src/helpers/dataFormatters.js
+++ b/src/helpers/dataFormatters.js
@@ -31,15 +31,15 @@ function formatTagName(isContainer, tagName, text) {
     : `<${tagName}>${text}</${tagName}>`;
 }
 
-function getItemStyles(initialOffset, currentOffset) {
-  if (!initialOffset || !currentOffset) {
+function getItemStyles(initialOffset, clientOffset) {
+  if (!initialOffset || !clientOffset) {
     return {
       display: "none",
     };
   }
 
-  const { x, y } = currentOffset;
-  const transform = `translate(${x}px, ${y}px)`;
+  const { x, y } = clientOffset;
+  const transform = `translateX(calc(${x}px - 50%)) translateY(calc(${y}px - 50%))`;
 
   return {
     transform,


### PR DESCRIPTION
### 이전
드래그 시 dragPreview 위치가 일정하지 않아 드롭 시 혼란이 발생합니다.
유저의 입장에서는 마우스가 아니라 dragPreview를 drop area에 드롭하는 것이 자연스럽기 때문입니다.
![dragPreview_before](https://user-images.githubusercontent.com/60309558/146955211-95b7ca73-6d1c-4f2f-99b2-12566de48117.gif)

### 이후
드래그 시 마우스 위치에 dragPreview 중앙지점이 오도록 위치를 고정하였습니다.
![dragPreview_after](https://user-images.githubusercontent.com/60309558/146955186-dde97c22-6acd-42b4-9460-d8adb559a522.gif)

관련하여 dataFormatters의 getItemStyles 수정하였습니다.
  - 각각 translateX, translateY에 -50% 값을 주어 중앙에 오도록 했습니다.


CustomDragLayer 컴포넌트 내부 로직을 수정하였습니다.
  - useDragLayer 훅에서 getSourceClientOffset로 받아오던 x, y 좌표를 getClientOffset로 받아오도록 수정하였습니다.
  - 위에서 적용한 translate 값이 적용되도록 position을 변경하였습니다.

위의 아이디어는 아래에서 얻었습니다.
https://github.com/react-dnd/react-dnd/issues/232#issuecomment-504710984