### PR TITLE
Modify: getChallengeList api

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,14 +1,16 @@
 import axios from "axios";
 
 const baseURL = process.env.REACT_APP_API_SERVER_URI;
+const isUsingGithubAPI = baseURL.startsWith("https://raw.githubusercontent.com");
 
 async function getChallengeList() {
   try {
-    const res = await axios.get(`${baseURL}/challenges`);
+    const requestURL = isUsingGithubAPI ? `${baseURL}/challenges/index` : `${baseURL}/challenges`;
+    const res = await axios.get(requestURL);
 
     return res.data;
   } catch (err) {
-    if (err.status === 500) {
+    if (err.status >= 500) {
       throw new Error("internal server error");
     }
 
@@ -22,7 +24,7 @@ async function getChallenge(id) {
 
     return res.data;
   } catch (err) {
-    if (err.status === 500) {
+    if (err.status >= 500) {
       throw new Error("internal server error");
     }
 

--- a/src/api/index.spec.js
+++ b/src/api/index.spec.js
@@ -1,0 +1,42 @@
+const mockGet = jest.fn();
+
+jest.mock("axios", () => ({
+  get: mockGet.mockReturnValue({ data: {} }),
+}));
+
+function setUp({ serverURI }) {
+  jest.resetModules();
+  process.env.REACT_APP_API_SERVER_URI = serverURI;
+
+  // importing getChallengeList should be setting env
+  // eslint-disable-next-line global-require
+  const { getChallengeList } = require(".");
+
+  return getChallengeList;
+}
+
+describe("api isUsingGithubAPI option test", () => {
+  it("getChallengeList get index file when isUsingGithubAPI is false", async () => {
+    const mockBaseURL = "https://original.url";
+    const getChallengeList = setUp({ serverURI: mockBaseURL });
+
+    expect(mockGet).toBeCalledTimes(0);
+
+    await getChallengeList();
+
+    expect(mockGet).toBeCalledTimes(1);
+    expect(mockGet).toBeCalledWith(`${mockBaseURL}/challenges`);
+  });
+
+  it("getChallengeList get index file when isUsingGithubAPI is true", async () => {
+    const mockBaseURL = "https://raw.githubusercontent.com";
+    const getChallengeList = setUp({ serverURI: mockBaseURL });
+
+    expect(mockGet).toBeCalledTimes(0);
+
+    await getChallengeList();
+
+    expect(mockGet).toBeCalledTimes(1);
+    expect(mockGet).toBeCalledWith(`${mockBaseURL}/challenges/index`);
+  });
+});

--- a/src/api/index.spec.js
+++ b/src/api/index.spec.js
@@ -1,42 +1,43 @@
-const mockGet = jest.fn();
-
-jest.mock("axios", () => ({
-  get: mockGet.mockReturnValue({ data: {} }),
-}));
-
-function setUp({ serverURI }) {
+function setUp({ serverURL }) {
   jest.resetModules();
-  process.env.REACT_APP_API_SERVER_URI = serverURI;
+  process.env.REACT_APP_API_SERVER_URI = serverURL;
 
-  // importing getChallengeList should be setting env
+  // re-import axios because of jest.resetModules();
+  // eslint-disable-next-line global-require
+  const axios = require("axios");
+
+  jest.spyOn(axios, "get")
+    .mockImplementation(() => ({ data: null }));
+
+  // importing getChallengeList should be going after setting env
   // eslint-disable-next-line global-require
   const { getChallengeList } = require(".");
 
-  return getChallengeList;
+  return { axios, getChallengeList };
 }
 
 describe("api isUsingGithubAPI option test", () => {
   it("getChallengeList get index file when isUsingGithubAPI is false", async () => {
-    const mockBaseURL = "https://original.url";
-    const getChallengeList = setUp({ serverURI: mockBaseURL });
+    const mockBaseURL = "https://localhost:3000";
+    const { axios, getChallengeList } = setUp({ serverURL: mockBaseURL });
 
-    expect(mockGet).toBeCalledTimes(0);
+    expect(axios.get).toBeCalledTimes(0);
 
     await getChallengeList();
 
-    expect(mockGet).toBeCalledTimes(1);
-    expect(mockGet).toBeCalledWith(`${mockBaseURL}/challenges`);
+    expect(axios.get).toBeCalledTimes(1);
+    expect(axios.get).toBeCalledWith(`${mockBaseURL}/challenges`);
   });
 
   it("getChallengeList get index file when isUsingGithubAPI is true", async () => {
     const mockBaseURL = "https://raw.githubusercontent.com";
-    const getChallengeList = setUp({ serverURI: mockBaseURL });
+    const { axios, getChallengeList } = setUp({ serverURL: mockBaseURL });
 
-    expect(mockGet).toBeCalledTimes(0);
+    expect(axios.get).toBeCalledTimes(0);
 
     await getChallengeList();
 
-    expect(mockGet).toBeCalledTimes(1);
-    expect(mockGet).toBeCalledWith(`${mockBaseURL}/challenges/index`);
+    expect(axios.get).toBeCalledTimes(1);
+    expect(axios.get).toBeCalledWith(`${mockBaseURL}/challenges/index`);
   });
 });


### PR DESCRIPTION
closes #89 

데이터 보관 위치로 **1. 웹상의 공개된 uri에서 받아온다.** 를 택하여,
데이터를 서버 레포지토리에 업로드 후 클라이언트에서 환경변수를 변경할 수 있도록 수정하였습니다.
데이터 관련 서버 PR: https://github.com/mark-up-blocks/mark-up-blocks-server/pull/22

본 PR은 위 이슈 2번 **데이터 관련 api 대체 작업**입니다.
getCHallengeList api에 `challenges/index` 파일에 대한 처리가 추가되었습니다.

