### PR TITLE
Fix style update for mobile

### DIFF
--- a/src/components/Challenge/DndInterface/DropArea/index.jsx
+++ b/src/components/Challenge/DndInterface/DropArea/index.jsx
@@ -62,7 +62,7 @@ const Area = styled.div`
 
   ::after {
     position: absolute;
-    width: 100%;
+    width: calc(100% - 4px);
     padding: 2px;
     margin-top: -2px;
     background-color: ${({ isHighlighted, theme }) => (isHighlighted ? theme.color.preview : "transparent")};

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -109,11 +109,11 @@ DropContainer.defaultProps = {
 };
 
 const FirstDropArea = styled(DropArea)`
-  margin: 4px 20px;
+  margin: 4px 24px 4px 20px;
 `;
 
 const BackwardDropArea = styled(DropArea)`
-  margin: 4px 0;
+  margin: 4px 4px 4px 0;
 `;
 
 const TextTag = styled.div`

--- a/src/components/Challenge/index.jsx
+++ b/src/components/Challenge/index.jsx
@@ -92,7 +92,7 @@ function Challenge() {
         <>
           <Display />
           <DndInterface onDrop={handleDrop} />
-          <ResetButton value="reset" onClick={handleReset} />
+          <ResetButton value="Reset" onClick={handleReset} />
         </>
       )}
     </ChallengeWrapper>
@@ -107,7 +107,7 @@ const ChallengeWrapper = styled.div`
 
   @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}) {
     grid-template-rows: unset;
-    padding-bottom: 50px;
+    padding-bottom: 250px;
   }
 `;
 
@@ -124,6 +124,11 @@ const ResetButton = styled(Button)`
 
   :hover {
     background-color: ${({ theme }) => theme.color.point};
+  }
+
+  @media screen and (max-width: ${({ theme }) => theme.screenSize.maxWidth.mobile}) {
+    position: unset;
+    margin: 20px 2px 0 auto;
   }
 `;
 


### PR DESCRIPTION
[47ba4dc](47ba4dc12ecab18baab5c51e7faf6e1cec1b660c)
Before
floating reset button in mobile web is uncomfortable, and padding bottom too narrow for mobile
![floatingButton-before](https://user-images.githubusercontent.com/60309558/156158517-62e9dd6c-813e-4730-8044-7acaf495bda8.gif)

After
![floatingButton-after](https://user-images.githubusercontent.com/60309558/156158512-ef83734e-bcc0-4205-871b-94c6759d3d74.gif)

---
[5605fde](https://github.com/mark-up-blocks/mark-up-blocks-client/commit/5605fdef5d78f29295e17158e837dce7549e719e)
Before
unnecessary scroll because of `content: " "`
![scroll-before](https://user-images.githubusercontent.com/60309558/156158506-d3e49fae-79d1-46d4-95f3-8b9294329b0c.gif)

After
![scroll-after](https://user-images.githubusercontent.com/60309558/156158495-3ededfaf-79a6-4d7f-92c6-ca24fdb94264.gif)


