### PR TITLE
Add DropArea inner wrapper to adjust style

### DIFF
--- a/src/components/Challenge/DndInterface/DropArea/index.jsx
+++ b/src/components/Challenge/DndInterface/DropArea/index.jsx
@@ -6,7 +6,7 @@ import styled from "styled-components";
 import { DRAGGABLE_TYPE } from "../../../../constants";
 
 function DropArea({
-  _id, index, onDrop, onClick, className, needHighlight,
+  _id, index, onDrop, onClick, highlightClassName, className, needHighlight,
 }) {
   const [{ hovered }, dropRef] = useDrop(() => ({
     accept: Object.values(DRAGGABLE_TYPE),
@@ -34,9 +34,10 @@ function DropArea({
     <Area
       ref={dropRef}
       className={className}
-      isHighlighted={hovered && needHighlight}
       onClick={handleClick}
-    />
+    >
+      <Highlight className={highlightClassName} isHighlighted={hovered && needHighlight} />
+    </Area>
   );
 }
 
@@ -45,29 +46,26 @@ DropArea.propTypes = {
   index: PropTypes.number,
   onDrop: PropTypes.func.isRequired,
   onClick: PropTypes.func.isRequired,
+  highlightClassName: PropTypes.string,
   className: PropTypes.string,
   needHighlight: PropTypes.bool,
 };
 
 DropArea.defaultProps = {
   index: -1,
+  highlightClassName: "",
   className: "",
   needHighlight: false,
 };
 
 const Area = styled.div`
-  position: relative;
-  padding: 2px 0;
   cursor: pointer;
+`;
 
-  ::after {
-    position: absolute;
-    width: calc(100% - 4px);
-    padding: 2px;
-    margin-top: -2px;
-    background-color: ${({ isHighlighted, theme }) => (isHighlighted ? theme.color.preview : "transparent")};
-    content: " ";
-  }
+const Highlight = styled.div`
+  padding: 2px;
+  margin-top: -3px;
+  background-color: ${({ isHighlighted, theme }) => (isHighlighted ? theme.color.preview : "transparent")};
 `;
 
 export default DropArea;

--- a/src/components/Challenge/DndInterface/DropContainer/index.jsx
+++ b/src/components/Challenge/DndInterface/DropContainer/index.jsx
@@ -34,7 +34,7 @@ function DropContainer({
         onDrop={onDrop}
         index={0}
         onClick={onClick}
-        className={isDropAreaActive ? "drop-guide" : ""}
+        highlightClassName={isDropAreaActive ? "drop-guide" : ""}
         needHighlight
       />
       <>
@@ -78,7 +78,7 @@ function DropContainer({
               onDrop={onDrop}
               onClick={onClick}
               index={index + 1}
-              className={isDropAreaActive ? "drop-guide" : ""}
+              highlightClassName={isDropAreaActive ? "drop-guide" : ""}
               needHighlight
             />
           </Draggable>
@@ -109,11 +109,19 @@ DropContainer.defaultProps = {
 };
 
 const FirstDropArea = styled(DropArea)`
-  margin: 4px 24px 4px 20px;
+  ${({ needHighlight }) => (needHighlight
+    ? `position: relative;
+    margin: -8px;
+    padding: 12px 32px 12px 28px`
+    : "padding: 4px 24px 4px 20px")};
 `;
 
 const BackwardDropArea = styled(DropArea)`
-  margin: 4px 4px 4px 0;
+    ${({ needHighlight }) => (needHighlight
+    ? `position: relative;
+    margin: -8px;
+    padding: 12px 12px 12px 8px`
+    : "padding: 4px 4px 4px 0")}
 `;
 
 const TextTag = styled.div`
@@ -121,6 +129,7 @@ const TextTag = styled.div`
     position: absolute;
     right: 100%;
     margin-right: -20px;
+    margin-top: 3px;
     text-align: right;
     font-size: 0.8rem;
     counter-increment: line;


### PR DESCRIPTION
드래그인식 범위 넓히기 of https://github.com/mark-up-blocks/mark-up-blocks-client/issues/84

`DropArea` 컴포넌트 내에 자식 컴포넌트 `Highlight`를 추가하여 아래와 같이 역할 구분
- 드롭영역을 담당할 transparent wrapper - `DropArea`
- 하이라이팅 시 스타일을 담당할 child - `Highlight`

Before
![dropareaMargin_before](https://user-images.githubusercontent.com/60309558/161294158-e20cf0a7-005d-4cee-af48-501d85a6f008.gif)

After
![dropareaMargin_after](https://user-images.githubusercontent.com/60309558/161294207-46a5831c-7c9f-45b2-9cec-d3daf3bd6069.gif)

