### PR TITLE
Apply dynamic import of dnd backend

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,23 +3,31 @@ import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
 import { DndProvider } from "react-dnd";
-import { HTML5Backend } from "react-dnd-html5-backend";
-import { TouchBackend } from "react-dnd-touch-backend";
 import App from "./App";
 import store from "./app/store";
 import isTouchDevice from "./helpers/device";
 
-const backend = isTouchDevice() ? TouchBackend : HTML5Backend;
-const container = document.getElementById("root");
-const root = createRoot(container);
-root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <DndProvider backend={backend}>
-        <Router>
-          <App />
-        </Router>
-      </DndProvider>
-    </Provider>
-  </React.StrictMode>,
-);
+const render = (backend) => {
+  const container = document.getElementById("root");
+  const root = createRoot(container);
+
+  root.render(
+    <React.StrictMode>
+      <Provider store={store}>
+        <DndProvider backend={backend}>
+          <Router>
+            <App />
+          </Router>
+        </DndProvider>
+      </Provider>
+    </React.StrictMode>,
+  );
+};
+
+if (isTouchDevice()) {
+  import("react-dnd-touch-backend")
+    .then(({ TouchBackend }) => render(TouchBackend));
+} else {
+  import("react-dnd-html5-backend")
+    .then(({ HTML5Backend }) => render(HTML5Backend));
+}


### PR DESCRIPTION
backend를 `isTouchDevice` 함수로 판별하면 필요한 dnd backend가 정해지므로, useless backend는 import 되지 않도록 수정했습니다.
![image](https://user-images.githubusercontent.com/60309558/164981264-55fd7cf1-f9e5-49b7-95a3-62fdcfa1f98b.png)

다만 `dragPreview`를 위해서 `react-dnd-html5-backend`의 `getEmptyImage`가 사용되고 있어서,
TouchBackend의 경우에도 `react-dnd-html5-backend`가 여전히 import 되고 있습니다.

이후 해당 함수를 대체하거나 TreeShaking을 적용해볼 수 있을 것 같습니다.
